### PR TITLE
Add Sail for bit-manip instructions that use Sail library functions.

### DIFF
--- a/src/b-st-ext.adoc
+++ b/src/b-st-ext.adoc
@@ -1687,19 +1687,8 @@ Description::
 This instruction counts the number of 0's before the first 1, starting at the most-significant bit (i.e., XLEN-1) and progressing to bit 0. Accordingly, if the input is 0, the output is XLEN, and if the most-significant bit of the input is a 1, the output is 0.
 
 Operation::
-[source,sail]
---
-val HighestSetBit : forall ('N : Int), 'N >= 0. bits('N) -> int
-
-function HighestSetBit x = {
-  foreach (i from (xlen - 1) to 0 by 1 in dec)
-    if [x[i]] == 0b1 then return(i) else ();
-  return -1;
-}
-
-let rs = X(rs);
-X[rd] = (xlen - 1) - HighestSetBit(rs);
---
++
+sail::execute[clause="CLZ(_, _, _)",part=body,unindent]
 
 Included in::
 [%header,cols="4,2,2"]
@@ -1741,19 +1730,8 @@ This instruction counts the number of 0's before the first 1 starting at bit 31 
 Accordingly, if the least-significant word is 0, the output is 32, and if the most-significant bit of the word (i.e., bit 31) is a 1, the output is 0.
 
 Operation::
-[source,sail]
---
-val HighestSetBit32 : forall ('N : Int), 'N >= 0. bits('N) -> int
-
-function HighestSetBit32 x = {
-  foreach (i from 31 to 0 by 1 in dec)
-    if [x[i]] == 0b1 then return(i) else ();
-  return -1;
-}
-
-let rs = X(rs);
-X[rd] = 31 - HighestSetBit(rs);
---
++
+sail::execute[clause="CLZW(_, _, _)",part=body,unindent]
 
 Included in::
 [%header,cols="4,2,2"]
@@ -1886,19 +1864,8 @@ This instruction counts the number of 0's before the first 1, starting at the le
 Accordingly, if the input is 0, the output is XLEN, and if the least-significant bit of the input is a 1, the output is 0.
 
 Operation::
-[source,sail]
---
-val LowestSetBit : forall ('N : Int), 'N >= 0. bits('N) -> int
-
-function LowestSetBit x = {
-  foreach (i from 0 to (xlen - 1) by 1 in dec)
-    if [x[i]] == 0b1 then return(i) else ();
-  return xlen;
-}
-
-let rs = X(rs);
-X[rd] = LowestSetBit(rs);
---
++
+sail::execute[clause="CTZ(_, _, _)",part=body,unindent]
 
 Included in::
 [%header,cols="4,2,2"]
@@ -1939,19 +1906,8 @@ Description::
 This instruction counts the number of 0's before the first 1, starting at the least-significant bit (i.e., 0) and progressing to the most-significant bit of the least-significant word (i.e., 31). Accordingly, if the least-significant word is 0, the output is 32, and if the least-significant bit of the input is a 1, the output is 0.
 
 Operation::
-[source,sail]
---
-val LowestSetBit32 : forall ('N : Int), 'N >= 0. bits('N) -> int
-
-function LowestSetBit32 x = {
-  foreach (i from 0 to 31 by 1 in dec)
-    if [x[i]] == 0b1 then return(i) else ();
-  return 32;
-}
-
-let rs = X(rs);
-X[rd] = LowestSetBit32(rs);
---
++
+sail::execute[clause="CTZW(_, _, _)",part=body,unindent]
 
 Included in::
 [%header,cols="4,2,2"]


### PR DESCRIPTION
The helper functions (`count_leading_zeros()`/`count_trailing_zeros()`) used by these instructions cannot be shown since they are from the Sail library.