### PR TITLE
Replace Sail in the scalar and vector crypto "Supporting Sail code" sections.

### DIFF
--- a/src/scalar-crypto.adoc
+++ b/src/scalar-crypto.adoc
@@ -5079,346 +5079,106 @@ The
 link:https://alasdair.github.io/manual.html[Sail Manual]
 is recommended reading in order to best understand the supporting code.
 
-[source,sail]
-----
-/* Auxiliary function for performing GF multiplication */
-val xt2 : bits(8) -> bits(8)
-function xt2(x) = {
-  (x << 1) ^ (if bit_to_bool(x[7]) then 0x1b else 0x00)
-}
+include::sailcomment:xt2[]
 
-val xt3 : bits(8) -> bits(8)
-function xt3(x) = x ^ xt2(x)
+sail::xt2[part=source]
 
-/* Multiply 8-bit field element by 4-bit value for AES MixCols step */
-val gfmul : (bits(8), bits(4)) -> bits(8)
-function gfmul( x, y) = {
-  (if bit_to_bool(y[0]) then             x    else 0x00) ^
-  (if bit_to_bool(y[1]) then xt2(        x)   else 0x00) ^
-  (if bit_to_bool(y[2]) then xt2(xt2(    x))  else 0x00) ^
-  (if bit_to_bool(y[3]) then xt2(xt2(xt2(x))) else 0x00)
-}
+sail::xt3[part=source]
 
-/* 8-bit to 32-bit partial AES Mix Column - forwards */
-val aes_mixcolumn_byte_fwd : bits(8) -> bits(32)
-function aes_mixcolumn_byte_fwd(so) = {
-  gfmul(so, 0x3) @ so @ so @ gfmul(so, 0x2)
-}
+include::sailcomment:gfmul[]
 
-/* 8-bit to 32-bit partial AES Mix Column - inverse*/
-val aes_mixcolumn_byte_inv : bits(8) -> bits(32)
-function aes_mixcolumn_byte_inv(so) = {
-  gfmul(so, 0xb) @ gfmul(so, 0xd) @ gfmul(so, 0x9) @ gfmul(so, 0xe)
-}
+sail::gfmul[part=source]
 
-/* 32-bit to 32-bit AES forward MixColumn */
-val aes_mixcolumn_fwd : bits(32) -> bits(32)
-function aes_mixcolumn_fwd(x) = {
-  let s0 : bits (8) = x[ 7.. 0];
-  let s1 : bits (8) = x[15.. 8];
-  let s2 : bits (8) = x[23..16];
-  let s3 : bits (8) = x[31..24];
-  let b0 : bits (8) = xt2(s0) ^ xt3(s1) ^    (s2) ^    (s3);
-  let b1 : bits (8) =    (s0) ^ xt2(s1) ^ xt3(s2) ^    (s3);
-  let b2 : bits (8) =    (s0) ^    (s1) ^ xt2(s2) ^ xt3(s3);
-  let b3 : bits (8) = xt3(s0) ^    (s1) ^    (s2) ^ xt2(s3);
-  b3 @ b2 @ b1 @ b0 /* Return value */
-}
+include::sailcomment:aes_mixcolumn_byte_fwd[]
 
-/* 32-bit to 32-bit AES inverse MixColumn */
-val aes_mixcolumn_inv : bits(32) -> bits(32)
-function aes_mixcolumn_inv(x) = {
-  let s0 : bits (8) = x[ 7.. 0];
-  let s1 : bits (8) = x[15.. 8];
-  let s2 : bits (8) = x[23..16];
-  let s3 : bits (8) = x[31..24];
-  let b0 : bits (8) = gfmul(s0, 0xE) ^ gfmul(s1, 0xB) ^ gfmul(s2, 0xD) ^ gfmul(s3, 0x9);
-  let b1 : bits (8) = gfmul(s0, 0x9) ^ gfmul(s1, 0xE) ^ gfmul(s2, 0xB) ^ gfmul(s3, 0xD);
-  let b2 : bits (8) = gfmul(s0, 0xD) ^ gfmul(s1, 0x9) ^ gfmul(s2, 0xE) ^ gfmul(s3, 0xB);
-  let b3 : bits (8) = gfmul(s0, 0xB) ^ gfmul(s1, 0xD) ^ gfmul(s2, 0x9) ^ gfmul(s3, 0xE);
-  b3 @ b2 @ b1 @ b0 /* Return value */
-}
+sail::aes_mixcolumn_byte_fwd[part=source]
 
-/* Turn a round number into a round constant for AES. Note that the
-   AES64KS1I instruction is defined such that the r argument is always
-   in the range 0x0..0xA. Values of rnum outside the range 0x0..0xA
-   do not decode to the AES64KS1I instruction. The 0xA case is used
-   specifically for the AES-256 KeySchedule, and this function is never
-   called in that case. */
-val aes_decode_rcon : bits(4) -> bits(32)
-function aes_decode_rcon(r) = {
-  assert(r <_u 0xA);
-  match r {
-    0x0 => 0x00000001,
-    0x1 => 0x00000002,
-    0x2 => 0x00000004,
-    0x3 => 0x00000008,
-    0x4 => 0x00000010,
-    0x5 => 0x00000020,
-    0x6 => 0x00000040,
-    0x7 => 0x00000080,
-    0x8 => 0x0000001b,
-    0x9 => 0x00000036,
-    _   => internal_error(__FILE__, __LINE__, "Unexpected AES r") /* unreachable -- required to silence Sail warning */
-  }
-}
+include::sailcomment:aes_mixcolumn_byte_inv[]
 
-/* SM4 SBox - only one sbox for forwards and inverse */
-let sm4_sbox_table : vector(256, bits(8)) = [
-0xD6, 0x90, 0xE9, 0xFE, 0xCC, 0xE1, 0x3D, 0xB7, 0x16, 0xB6, 0x14, 0xC2, 0x28,
-0xFB, 0x2C, 0x05, 0x2B, 0x67, 0x9A, 0x76, 0x2A, 0xBE, 0x04, 0xC3, 0xAA, 0x44,
-0x13, 0x26, 0x49, 0x86, 0x06, 0x99, 0x9C, 0x42, 0x50, 0xF4, 0x91, 0xEF, 0x98,
-0x7A, 0x33, 0x54, 0x0B, 0x43, 0xED, 0xCF, 0xAC, 0x62, 0xE4, 0xB3, 0x1C, 0xA9,
-0xC9, 0x08, 0xE8, 0x95, 0x80, 0xDF, 0x94, 0xFA, 0x75, 0x8F, 0x3F, 0xA6, 0x47,
-0x07, 0xA7, 0xFC, 0xF3, 0x73, 0x17, 0xBA, 0x83, 0x59, 0x3C, 0x19, 0xE6, 0x85,
-0x4F, 0xA8, 0x68, 0x6B, 0x81, 0xB2, 0x71, 0x64, 0xDA, 0x8B, 0xF8, 0xEB, 0x0F,
-0x4B, 0x70, 0x56, 0x9D, 0x35, 0x1E, 0x24, 0x0E, 0x5E, 0x63, 0x58, 0xD1, 0xA2,
-0x25, 0x22, 0x7C, 0x3B, 0x01, 0x21, 0x78, 0x87, 0xD4, 0x00, 0x46, 0x57, 0x9F,
-0xD3, 0x27, 0x52, 0x4C, 0x36, 0x02, 0xE7, 0xA0, 0xC4, 0xC8, 0x9E, 0xEA, 0xBF,
-0x8A, 0xD2, 0x40, 0xC7, 0x38, 0xB5, 0xA3, 0xF7, 0xF2, 0xCE, 0xF9, 0x61, 0x15,
-0xA1, 0xE0, 0xAE, 0x5D, 0xA4, 0x9B, 0x34, 0x1A, 0x55, 0xAD, 0x93, 0x32, 0x30,
-0xF5, 0x8C, 0xB1, 0xE3, 0x1D, 0xF6, 0xE2, 0x2E, 0x82, 0x66, 0xCA, 0x60, 0xC0,
-0x29, 0x23, 0xAB, 0x0D, 0x53, 0x4E, 0x6F, 0xD5, 0xDB, 0x37, 0x45, 0xDE, 0xFD,
-0x8E, 0x2F, 0x03, 0xFF, 0x6A, 0x72, 0x6D, 0x6C, 0x5B, 0x51, 0x8D, 0x1B, 0xAF,
-0x92, 0xBB, 0xDD, 0xBC, 0x7F, 0x11, 0xD9, 0x5C, 0x41, 0x1F, 0x10, 0x5A, 0xD8,
-0x0A, 0xC1, 0x31, 0x88, 0xA5, 0xCD, 0x7B, 0xBD, 0x2D, 0x74, 0xD0, 0x12, 0xB8,
-0xE5, 0xB4, 0xB0, 0x89, 0x69, 0x97, 0x4A, 0x0C, 0x96, 0x77, 0x7E, 0x65, 0xB9,
-0xF1, 0x09, 0xC5, 0x6E, 0xC6, 0x84, 0x18, 0xF0, 0x7D, 0xEC, 0x3A, 0xDC, 0x4D,
-0x20, 0x79, 0xEE, 0x5F, 0x3E, 0xD7, 0xCB, 0x39, 0x48
-]
+sail::aes_mixcolumn_byte_inv[part=source]
 
-let aes_sbox_fwd_table : vector(256, bits(8)) = [
-0x63, 0x7c, 0x77, 0x7b, 0xf2, 0x6b, 0x6f, 0xc5, 0x30, 0x01, 0x67, 0x2b, 0xfe,
-0xd7, 0xab, 0x76, 0xca, 0x82, 0xc9, 0x7d, 0xfa, 0x59, 0x47, 0xf0, 0xad, 0xd4,
-0xa2, 0xaf, 0x9c, 0xa4, 0x72, 0xc0, 0xb7, 0xfd, 0x93, 0x26, 0x36, 0x3f, 0xf7,
-0xcc, 0x34, 0xa5, 0xe5, 0xf1, 0x71, 0xd8, 0x31, 0x15, 0x04, 0xc7, 0x23, 0xc3,
-0x18, 0x96, 0x05, 0x9a, 0x07, 0x12, 0x80, 0xe2, 0xeb, 0x27, 0xb2, 0x75, 0x09,
-0x83, 0x2c, 0x1a, 0x1b, 0x6e, 0x5a, 0xa0, 0x52, 0x3b, 0xd6, 0xb3, 0x29, 0xe3,
-0x2f, 0x84, 0x53, 0xd1, 0x00, 0xed, 0x20, 0xfc, 0xb1, 0x5b, 0x6a, 0xcb, 0xbe,
-0x39, 0x4a, 0x4c, 0x58, 0xcf, 0xd0, 0xef, 0xaa, 0xfb, 0x43, 0x4d, 0x33, 0x85,
-0x45, 0xf9, 0x02, 0x7f, 0x50, 0x3c, 0x9f, 0xa8, 0x51, 0xa3, 0x40, 0x8f, 0x92,
-0x9d, 0x38, 0xf5, 0xbc, 0xb6, 0xda, 0x21, 0x10, 0xff, 0xf3, 0xd2, 0xcd, 0x0c,
-0x13, 0xec, 0x5f, 0x97, 0x44, 0x17, 0xc4, 0xa7, 0x7e, 0x3d, 0x64, 0x5d, 0x19,
-0x73, 0x60, 0x81, 0x4f, 0xdc, 0x22, 0x2a, 0x90, 0x88, 0x46, 0xee, 0xb8, 0x14,
-0xde, 0x5e, 0x0b, 0xdb, 0xe0, 0x32, 0x3a, 0x0a, 0x49, 0x06, 0x24, 0x5c, 0xc2,
-0xd3, 0xac, 0x62, 0x91, 0x95, 0xe4, 0x79, 0xe7, 0xc8, 0x37, 0x6d, 0x8d, 0xd5,
-0x4e, 0xa9, 0x6c, 0x56, 0xf4, 0xea, 0x65, 0x7a, 0xae, 0x08, 0xba, 0x78, 0x25,
-0x2e, 0x1c, 0xa6, 0xb4, 0xc6, 0xe8, 0xdd, 0x74, 0x1f, 0x4b, 0xbd, 0x8b, 0x8a,
-0x70, 0x3e, 0xb5, 0x66, 0x48, 0x03, 0xf6, 0x0e, 0x61, 0x35, 0x57, 0xb9, 0x86,
-0xc1, 0x1d, 0x9e, 0xe1, 0xf8, 0x98, 0x11, 0x69, 0xd9, 0x8e, 0x94, 0x9b, 0x1e,
-0x87, 0xe9, 0xce, 0x55, 0x28, 0xdf, 0x8c, 0xa1, 0x89, 0x0d, 0xbf, 0xe6, 0x42,
-0x68, 0x41, 0x99, 0x2d, 0x0f, 0xb0, 0x54, 0xbb, 0x16
-]
+include::sailcomment:aes_mixcolumn_fwd[]
 
-let aes_sbox_inv_table : vector(256, bits(8)) = [
-0x52, 0x09, 0x6a, 0xd5, 0x30, 0x36, 0xa5, 0x38, 0xbf, 0x40, 0xa3, 0x9e, 0x81,
-0xf3, 0xd7, 0xfb, 0x7c, 0xe3, 0x39, 0x82, 0x9b, 0x2f, 0xff, 0x87, 0x34, 0x8e,
-0x43, 0x44, 0xc4, 0xde, 0xe9, 0xcb, 0x54, 0x7b, 0x94, 0x32, 0xa6, 0xc2, 0x23,
-0x3d, 0xee, 0x4c, 0x95, 0x0b, 0x42, 0xfa, 0xc3, 0x4e, 0x08, 0x2e, 0xa1, 0x66,
-0x28, 0xd9, 0x24, 0xb2, 0x76, 0x5b, 0xa2, 0x49, 0x6d, 0x8b, 0xd1, 0x25, 0x72,
-0xf8, 0xf6, 0x64, 0x86, 0x68, 0x98, 0x16, 0xd4, 0xa4, 0x5c, 0xcc, 0x5d, 0x65,
-0xb6, 0x92, 0x6c, 0x70, 0x48, 0x50, 0xfd, 0xed, 0xb9, 0xda, 0x5e, 0x15, 0x46,
-0x57, 0xa7, 0x8d, 0x9d, 0x84, 0x90, 0xd8, 0xab, 0x00, 0x8c, 0xbc, 0xd3, 0x0a,
-0xf7, 0xe4, 0x58, 0x05, 0xb8, 0xb3, 0x45, 0x06, 0xd0, 0x2c, 0x1e, 0x8f, 0xca,
-0x3f, 0x0f, 0x02, 0xc1, 0xaf, 0xbd, 0x03, 0x01, 0x13, 0x8a, 0x6b, 0x3a, 0x91,
-0x11, 0x41, 0x4f, 0x67, 0xdc, 0xea, 0x97, 0xf2, 0xcf, 0xce, 0xf0, 0xb4, 0xe6,
-0x73, 0x96, 0xac, 0x74, 0x22, 0xe7, 0xad, 0x35, 0x85, 0xe2, 0xf9, 0x37, 0xe8,
-0x1c, 0x75, 0xdf, 0x6e, 0x47, 0xf1, 0x1a, 0x71, 0x1d, 0x29, 0xc5, 0x89, 0x6f,
-0xb7, 0x62, 0x0e, 0xaa, 0x18, 0xbe, 0x1b, 0xfc, 0x56, 0x3e, 0x4b, 0xc6, 0xd2,
-0x79, 0x20, 0x9a, 0xdb, 0xc0, 0xfe, 0x78, 0xcd, 0x5a, 0xf4, 0x1f, 0xdd, 0xa8,
-0x33, 0x88, 0x07, 0xc7, 0x31, 0xb1, 0x12, 0x10, 0x59, 0x27, 0x80, 0xec, 0x5f,
-0x60, 0x51, 0x7f, 0xa9, 0x19, 0xb5, 0x4a, 0x0d, 0x2d, 0xe5, 0x7a, 0x9f, 0x93,
-0xc9, 0x9c, 0xef, 0xa0, 0xe0, 0x3b, 0x4d, 0xae, 0x2a, 0xf5, 0xb0, 0xc8, 0xeb,
-0xbb, 0x3c, 0x83, 0x53, 0x99, 0x61, 0x17, 0x2b, 0x04, 0x7e, 0xba, 0x77, 0xd6,
-0x26, 0xe1, 0x69, 0x14, 0x63, 0x55, 0x21, 0x0c, 0x7d
-]
+sail::aes_mixcolumn_fwd[part=source]
 
-/* Lookup function - takes an index and a table, and retrieves the
- * x'th element of that table. Note that the Sail vector literals
- * start at index 255, and go down to 0.
- */
-val sbox_lookup : (bits(8), vector(256, bits(8))) -> bits(8)
-function sbox_lookup(x, table) = {
-  table[255 - unsigned(x)]
-}
+include::sailcomment:aes_mixcolumn_inv[]
 
-/* Easy function to perform a forward AES SBox operation on 1 byte. */
-val aes_sbox_fwd : bits(8) -> bits(8)
-function aes_sbox_fwd(x) = sbox_lookup(x, aes_sbox_fwd_table)
+sail::aes_mixcolumn_inv[part=source]
 
-/* Easy function to perform an inverse AES SBox operation on 1 byte. */
-val aes_sbox_inv : bits(8) -> bits(8)
-function aes_sbox_inv(x) = sbox_lookup(x, aes_sbox_inv_table)
+include::sailcomment:aes_decode_rcon[]
 
-/* AES SubWord function used in the key expansion
- * - Applies the forward sbox to each byte in the input word.
- */
-val aes_subword_fwd : bits(32) -> bits(32)
-function aes_subword_fwd(x) = {
-  aes_sbox_fwd(x[31..24]) @
-  aes_sbox_fwd(x[23..16]) @
-  aes_sbox_fwd(x[15.. 8]) @
-  aes_sbox_fwd(x[ 7.. 0])
-}
+sail::aes_decode_rcon[part=source]
 
-/* AES Inverse SubWord function.
- * - Applies the inverse sbox to each byte in the input word.
- */
-val aes_subword_inv : bits(32) -> bits(32)
-function aes_subword_inv(x) = {
-  aes_sbox_inv(x[31..24]) @
-  aes_sbox_inv(x[23..16]) @
-  aes_sbox_inv(x[15.. 8]) @
-  aes_sbox_inv(x[ 7.. 0])
-}
+include::sailcomment:sm4_sbox_table_doc[type=anchor]
 
-/* Easy function to perform an SM4 SBox operation on 1 byte. */
-val sm4_sbox : bits(8) -> bits(8)
-function sm4_sbox(x) = sbox_lookup(x, sm4_sbox_table)
+sail::sm4_sbox_table[type=let, part=source]
 
-val aes_get_column : (bits(128), nat) -> bits(32)
-function aes_get_column(state,c) = (state >> (to_bits(7, 32 * c)))[31..0]
+sail::aes_sbox_fwd_table[type=let, part=source]
 
-/* 64-bit to 64-bit function which applies the AES forward sbox to each byte
- * in a 64-bit word.
- */
-val aes_apply_fwd_sbox_to_each_byte : bits(64) -> bits(64)
-function aes_apply_fwd_sbox_to_each_byte(x) = {
-  aes_sbox_fwd(x[63..56]) @
-  aes_sbox_fwd(x[55..48]) @
-  aes_sbox_fwd(x[47..40]) @
-  aes_sbox_fwd(x[39..32]) @
-  aes_sbox_fwd(x[31..24]) @
-  aes_sbox_fwd(x[23..16]) @
-  aes_sbox_fwd(x[15.. 8]) @
-  aes_sbox_fwd(x[ 7.. 0])
-}
+sail::aes_sbox_inv_table[type=let, part=source]
 
-/* 64-bit to 64-bit function which applies the AES inverse sbox to each byte
- * in a 64-bit word.
- */
-val aes_apply_inv_sbox_to_each_byte : bits(64) -> bits(64)
-function aes_apply_inv_sbox_to_each_byte(x) = {
-  aes_sbox_inv(x[63..56]) @
-  aes_sbox_inv(x[55..48]) @
-  aes_sbox_inv(x[47..40]) @
-  aes_sbox_inv(x[39..32]) @
-  aes_sbox_inv(x[31..24]) @
-  aes_sbox_inv(x[23..16]) @
-  aes_sbox_inv(x[15.. 8]) @
-  aes_sbox_inv(x[ 7.. 0])
-}
+include::sailcomment:sbox_lookup[]
 
-/*
- * AES full-round transformation functions.
- */
+sail::sbox_lookup[part=source]
 
-val getbyte : (bits(64), int) -> bits(8)
-function getbyte(x, i) = (x >> to_bits(6, i * 8))[7..0]
+include::sailcomment:aes_sbox_fwd[]
 
-val aes_rv64_shiftrows_fwd : (bits(64), bits(64)) -> bits(64)
-function aes_rv64_shiftrows_fwd(rs2, rs1) = {
-  getbyte(rs1, 3) @
-  getbyte(rs2, 6) @
-  getbyte(rs2, 1) @
-  getbyte(rs1, 4) @
-  getbyte(rs2, 7) @
-  getbyte(rs2, 2) @
-  getbyte(rs1, 5) @
-  getbyte(rs1, 0)
-}
+sail::aes_sbox_fwd[part=source]
 
-val aes_rv64_shiftrows_inv : (bits(64), bits(64)) -> bits(64)
-function aes_rv64_shiftrows_inv(rs2, rs1) = {
-  getbyte(rs2, 3) @
-  getbyte(rs2, 6) @
-  getbyte(rs1, 1) @
-  getbyte(rs1, 4) @
-  getbyte(rs1, 7) @
-  getbyte(rs2, 2) @
-  getbyte(rs2, 5) @
-  getbyte(rs1, 0)
-}
+include::sailcomment:aes_sbox_inv[]
 
-/* 128-bit to 128-bit implementation of the forward AES ShiftRows transform.
- * Byte 0 of state is input column 0, bits  7..0.
- * Byte 5 of state is input column 1, bits 15..8.
- */
-val aes_shift_rows_fwd : bits(128) -> bits(128)
-function aes_shift_rows_fwd(x) = {
-  let ic3 : bits(32) = aes_get_column(x, 3);
-  let ic2 : bits(32) = aes_get_column(x, 2);
-  let ic1 : bits(32) = aes_get_column(x, 1);
-  let ic0 : bits(32) = aes_get_column(x, 0);
-  let oc0 : bits(32) = ic0[31..24] @ ic1[23..16] @ ic2[15.. 8] @ ic3[ 7.. 0];
-  let oc1 : bits(32) = ic1[31..24] @ ic2[23..16] @ ic3[15.. 8] @ ic0[ 7.. 0];
-  let oc2 : bits(32) = ic2[31..24] @ ic3[23..16] @ ic0[15.. 8] @ ic1[ 7.. 0];
-  let oc3 : bits(32) = ic3[31..24] @ ic0[23..16] @ ic1[15.. 8] @ ic2[ 7.. 0];
-  (oc3 @ oc2 @ oc1 @ oc0) /* Return value */
-}
+sail::aes_sbox_inv[part=source]
 
-/* 128-bit to 128-bit implementation of the inverse AES ShiftRows transform.
- * Byte 0 of state is input column 0, bits  7..0.
- * Byte 5 of state is input column 1, bits 15..8.
- */
-val aes_shift_rows_inv : bits(128) -> bits(128)
-function aes_shift_rows_inv(x) = {
-  let ic3 : bits(32) = aes_get_column(x, 3); /* In column 3 */
-  let ic2 : bits(32) = aes_get_column(x, 2);
-  let ic1 : bits(32) = aes_get_column(x, 1);
-  let ic0 : bits(32) = aes_get_column(x, 0);
-  let oc0 : bits(32) = ic0[31..24] @ ic3[23..16] @ ic2[15.. 8] @ ic1[ 7.. 0];
-  let oc1 : bits(32) = ic1[31..24] @ ic0[23..16] @ ic3[15.. 8] @ ic2[ 7.. 0];
-  let oc2 : bits(32) = ic2[31..24] @ ic1[23..16] @ ic0[15.. 8] @ ic3[ 7.. 0];
-  let oc3 : bits(32) = ic3[31..24] @ ic2[23..16] @ ic1[15.. 8] @ ic0[ 7.. 0];
-  (oc3 @ oc2 @ oc1 @ oc0) /* Return value */
-}
+include::sailcomment:aes_subword_fwd[]
 
-/* Applies the forward sub-bytes step of AES to a 128-bit vector
- * representation of its state.
- */
-val aes_subbytes_fwd : bits(128) -> bits(128)
-function aes_subbytes_fwd(x) = {
-  let oc0 : bits(32) = aes_subword_fwd(aes_get_column(x, 0));
-  let oc1 : bits(32) = aes_subword_fwd(aes_get_column(x, 1));
-  let oc2 : bits(32) = aes_subword_fwd(aes_get_column(x, 2));
-  let oc3 : bits(32) = aes_subword_fwd(aes_get_column(x, 3));
-  (oc3 @ oc2 @ oc1 @ oc0) /* Return value */
-}
+sail::aes_subword_fwd[part=source]
 
-/* Applies the inverse sub-bytes step of AES to a 128-bit vector
- * representation of its state.
- */
-val aes_subbytes_inv : bits(128) -> bits(128)
-function aes_subbytes_inv(x) = {
-  let oc0 : bits(32) = aes_subword_inv(aes_get_column(x, 0));
-  let oc1 : bits(32) = aes_subword_inv(aes_get_column(x, 1));
-  let oc2 : bits(32) = aes_subword_inv(aes_get_column(x, 2));
-  let oc3 : bits(32) = aes_subword_inv(aes_get_column(x, 3));
-  (oc3 @ oc2 @ oc1 @ oc0) /* Return value */
-}
+include::sailcomment:aes_subword_inv[]
 
-/* Applies the forward MixColumns step of AES to a 128-bit vector
- * representation of its state.
- */
-val aes_mixcolumns_fwd : bits(128) -> bits(128)
-function aes_mixcolumns_fwd(x) = {
-  let oc0 : bits(32) = aes_mixcolumn_fwd(aes_get_column(x, 0));
-  let oc1 : bits(32) = aes_mixcolumn_fwd(aes_get_column(x, 1));
-  let oc2 : bits(32) = aes_mixcolumn_fwd(aes_get_column(x, 2));
-  let oc3 : bits(32) = aes_mixcolumn_fwd(aes_get_column(x, 3));
-  (oc3 @ oc2 @ oc1 @ oc0) /* Return value */
-}
+sail::aes_subword_inv[part=source]
 
-/* Applies the inverse MixColumns step of AES to a 128-bit vector
- * representation of its state.
- */
-val aes_mixcolumns_inv : bits(128) -> bits(128)
-function aes_mixcolumns_inv(x) = {
-  let oc0 : bits(32) = aes_mixcolumn_inv(aes_get_column(x, 0));
-  let oc1 : bits(32) = aes_mixcolumn_inv(aes_get_column(x, 1));
-  let oc2 : bits(32) = aes_mixcolumn_inv(aes_get_column(x, 2));
-  let oc3 : bits(32) = aes_mixcolumn_inv(aes_get_column(x, 3));
-  (oc3 @ oc2 @ oc1 @ oc0) /* Return value */
-}
-----
+include::sailcomment:sm4_sbox[]
+
+sail::sm4_sbox[part=source]
+
+sail::aes_get_column[part=source]
+
+include::sailcomment:aes_apply_fwd_sbox_to_each_byte[]
+
+sail::aes_apply_fwd_sbox_to_each_byte[part=source]
+
+include::sailcomment:aes_apply_inv_sbox_to_each_byte[]
+
+sail::aes_apply_inv_sbox_to_each_byte[part=source]
+
+include::sailcomment:aes_full_round_transformations_doc[type=anchor]
+
+sail::getbyte[part=source]
+
+sail::aes_rv64_shiftrows_fwd[part=source]
+
+sail::aes_rv64_shiftrows_inv[part=source]
+
+include::sailcomment:aes_shift_rows_fwd[]
+
+sail::aes_shift_rows_fwd[part=source]
+
+include::sailcomment:aes_shift_rows_inv[]
+
+sail::aes_shift_rows_inv[part=source]
+
+include::sailcomment:aes_subbytes_fwd[]
+
+sail::aes_subbytes_fwd[part=source]
+
+include::sailcomment:aes_subbytes_inv[]
+
+sail::aes_subbytes_inv[part=source]
+
+include::sailcomment:aes_mixcolumns_fwd[]
+
+sail::aes_mixcolumns_fwd[part=source]
+
+include::sailcomment:aes_mixcolumns_inv[]
+
+sail::aes_mixcolumns_inv[part=source]

--- a/src/vector-crypto.adoc
+++ b/src/vector-crypto.adoc
@@ -4136,4 +4136,3 @@ sail::rev8[type=val,part=source]
 sail::rev8[part=source]
 
 sail::zvk_sm4_subword[part=source]
-

--- a/src/vector-crypto.adoc
+++ b/src/vector-crypto.adoc
@@ -4019,349 +4019,112 @@ The
 link:https://alasdair.github.io/manual.html[Sail Manual]
 is recommended reading in order to best understand the supporting code.
 
+include::sailcomment:xt2[]
+
+sail::xt2[part=source]
+
+sail::xt3[part=source]
+
+include::sailcomment:gfmul[]
+
+sail::gfmul[part=source]
+
+include::sailcomment:aes_mixcolumn_byte_fwd[]
+
+sail::aes_mixcolumn_byte_fwd[part=source]
+
+include::sailcomment:aes_mixcolumn_byte_inv[]
+
+sail::aes_mixcolumn_byte_inv[part=source]
+
+include::sailcomment:aes_mixcolumn_fwd[]
+
+sail::aes_mixcolumn_fwd[part=source]
+
+include::sailcomment:aes_mixcolumn_inv[]
+
+sail::aes_mixcolumn_inv[part=source]
+
+include::sailcomment:aes_decode_rcon[]
+
+sail::aes_decode_rcon[part=source]
+
+include::sailcomment:sm4_sbox_table_doc[type=anchor]
+
+sail::sm4_sbox_table[type=let, part=source]
+
+sail::aes_sbox_fwd_table[type=let, part=source]
+
+sail::aes_sbox_inv_table[type=let, part=source]
+
+include::sailcomment:sbox_lookup[]
+
+sail::sbox_lookup[part=source]
+
+include::sailcomment:aes_sbox_fwd[]
+
+sail::aes_sbox_fwd[part=source]
+
+include::sailcomment:aes_sbox_inv[]
+
+sail::aes_sbox_inv[part=source]
+
+include::sailcomment:aes_subword_fwd[]
+
+sail::aes_subword_fwd[part=source]
+
+include::sailcomment:aes_subword_inv[]
+
+sail::aes_subword_inv[part=source]
+
+include::sailcomment:sm4_sbox[]
+
+sail::sm4_sbox[part=source]
+
+sail::aes_get_column[part=source]
+
+include::sailcomment:aes_apply_fwd_sbox_to_each_byte[]
+
+sail::aes_apply_fwd_sbox_to_each_byte[part=source]
+
+include::sailcomment:aes_apply_inv_sbox_to_each_byte[]
+
+sail::aes_apply_inv_sbox_to_each_byte[part=source]
+
+include::sailcomment:aes_full_round_transformations_doc[type=anchor]
+
+sail::getbyte[part=source]
+
+sail::aes_rv64_shiftrows_fwd[part=source]
+
+sail::aes_rv64_shiftrows_inv[part=source]
+
+include::sailcomment:aes_shift_rows_fwd[]
+
+sail::aes_shift_rows_fwd[part=source]
+
+include::sailcomment:aes_shift_rows_inv[]
+
+sail::aes_shift_rows_inv[part=source]
+
+include::sailcomment:aes_subbytes_fwd[]
+
+sail::aes_subbytes_fwd[part=source]
+
+include::sailcomment:aes_subbytes_inv[]
+
+sail::aes_subbytes_inv[part=source]
+
+include::sailcomment:aes_mixcolumns_fwd[]
+
+sail::aes_mixcolumns_fwd[part=source]
+
+include::sailcomment:aes_mixcolumns_inv[]
+
+sail::aes_mixcolumns_inv[part=source]
+
 [source,sail]
 ----
-/* Auxiliary function for performing GF multiplication */
-val xt2 : bits(8) -> bits(8)
-function xt2(x) = {
-  (x << 1) ^ (if bit_to_bool(x[7]) then 0x1b else 0x00)
-}
-
-val xt3 : bits(8) -> bits(8)
-function xt3(x) = x ^ xt2(x)
-
-/* Multiply 8-bit field element by 4-bit value for AES MixCols step */
-val gfmul : (bits(8), bits(4)) -> bits(8)
-function gfmul( x, y) = {
-  (if bit_to_bool(y[0]) then             x    else 0x00) ^
-  (if bit_to_bool(y[1]) then xt2(        x)   else 0x00) ^
-  (if bit_to_bool(y[2]) then xt2(xt2(    x))  else 0x00) ^
-  (if bit_to_bool(y[3]) then xt2(xt2(xt2(x))) else 0x00)
-}
-
-/* 8-bit to 32-bit partial AES Mix Column - forwards */
-val aes_mixcolumn_byte_fwd : bits(8) -> bits(32)
-function aes_mixcolumn_byte_fwd(so) = {
-  gfmul(so, 0x3) @ so @ so @ gfmul(so, 0x2)
-}
-
-/* 8-bit to 32-bit partial AES Mix Column - inverse*/
-val aes_mixcolumn_byte_inv : bits(8) -> bits(32)
-function aes_mixcolumn_byte_inv(so) = {
-  gfmul(so, 0xb) @ gfmul(so, 0xd) @ gfmul(so, 0x9) @ gfmul(so, 0xe)
-}
-
-/* 32-bit to 32-bit AES forward MixColumn */
-val aes_mixcolumn_fwd : bits(32) -> bits(32)
-function aes_mixcolumn_fwd(x) = {
-  let s0 : bits (8) = x[ 7.. 0];
-  let s1 : bits (8) = x[15.. 8];
-  let s2 : bits (8) = x[23..16];
-  let s3 : bits (8) = x[31..24];
-  let b0 : bits (8) = xt2(s0) ^ xt3(s1) ^    (s2) ^    (s3);
-  let b1 : bits (8) =    (s0) ^ xt2(s1) ^ xt3(s2) ^    (s3);
-  let b2 : bits (8) =    (s0) ^    (s1) ^ xt2(s2) ^ xt3(s3);
-  let b3 : bits (8) = xt3(s0) ^    (s1) ^    (s2) ^ xt2(s3);
-  b3 @ b2 @ b1 @ b0 /* Return value */
-}
-
-/* 32-bit to 32-bit AES inverse MixColumn */
-val aes_mixcolumn_inv : bits(32) -> bits(32)
-function aes_mixcolumn_inv(x) = {
-  let s0 : bits (8) = x[ 7.. 0];
-  let s1 : bits (8) = x[15.. 8];
-  let s2 : bits (8) = x[23..16];
-  let s3 : bits (8) = x[31..24];
-  let b0 : bits (8) = gfmul(s0, 0xE) ^ gfmul(s1, 0xB) ^ gfmul(s2, 0xD) ^ gfmul(s3, 0x9);
-  let b1 : bits (8) = gfmul(s0, 0x9) ^ gfmul(s1, 0xE) ^ gfmul(s2, 0xB) ^ gfmul(s3, 0xD);
-  let b2 : bits (8) = gfmul(s0, 0xD) ^ gfmul(s1, 0x9) ^ gfmul(s2, 0xE) ^ gfmul(s3, 0xB);
-  let b3 : bits (8) = gfmul(s0, 0xB) ^ gfmul(s1, 0xD) ^ gfmul(s2, 0x9) ^ gfmul(s3, 0xE);
-  b3 @ b2 @ b1 @ b0 /* Return value */
-}
-
-val aes_decode_rcon : bits(4) -> bits(32)
-function aes_decode_rcon(r) = {
-  match r {
-    0x0 => 0x00000001,
-    0x1 => 0x00000002,
-    0x2 => 0x00000004,
-    0x3 => 0x00000008,
-    0x4 => 0x00000010,
-    0x5 => 0x00000020,
-    0x6 => 0x00000040,
-    0x7 => 0x00000080,
-    0x8 => 0x0000001b,
-    0x9 => 0x00000036,
-    0xA => 0x00000000,
-    0xB => 0x00000000,
-    0xC => 0x00000000,
-    0xD => 0x00000000,
-    0xE => 0x00000000,
-    0xF => 0x00000000
-  }
-}
-
-/* SM4 SBox - only one sbox for forwards and inverse */
-let sm4_sbox_table : list(bits(8)) = [|
-0xD6, 0x90, 0xE9, 0xFE, 0xCC, 0xE1, 0x3D, 0xB7, 0x16, 0xB6, 0x14, 0xC2, 0x28,
-0xFB, 0x2C, 0x05, 0x2B, 0x67, 0x9A, 0x76, 0x2A, 0xBE, 0x04, 0xC3, 0xAA, 0x44,
-0x13, 0x26, 0x49, 0x86, 0x06, 0x99, 0x9C, 0x42, 0x50, 0xF4, 0x91, 0xEF, 0x98,
-0x7A, 0x33, 0x54, 0x0B, 0x43, 0xED, 0xCF, 0xAC, 0x62, 0xE4, 0xB3, 0x1C, 0xA9,
-0xC9, 0x08, 0xE8, 0x95, 0x80, 0xDF, 0x94, 0xFA, 0x75, 0x8F, 0x3F, 0xA6, 0x47,
-0x07, 0xA7, 0xFC, 0xF3, 0x73, 0x17, 0xBA, 0x83, 0x59, 0x3C, 0x19, 0xE6, 0x85,
-0x4F, 0xA8, 0x68, 0x6B, 0x81, 0xB2, 0x71, 0x64, 0xDA, 0x8B, 0xF8, 0xEB, 0x0F,
-0x4B, 0x70, 0x56, 0x9D, 0x35, 0x1E, 0x24, 0x0E, 0x5E, 0x63, 0x58, 0xD1, 0xA2,
-0x25, 0x22, 0x7C, 0x3B, 0x01, 0x21, 0x78, 0x87, 0xD4, 0x00, 0x46, 0x57, 0x9F,
-0xD3, 0x27, 0x52, 0x4C, 0x36, 0x02, 0xE7, 0xA0, 0xC4, 0xC8, 0x9E, 0xEA, 0xBF,
-0x8A, 0xD2, 0x40, 0xC7, 0x38, 0xB5, 0xA3, 0xF7, 0xF2, 0xCE, 0xF9, 0x61, 0x15,
-0xA1, 0xE0, 0xAE, 0x5D, 0xA4, 0x9B, 0x34, 0x1A, 0x55, 0xAD, 0x93, 0x32, 0x30,
-0xF5, 0x8C, 0xB1, 0xE3, 0x1D, 0xF6, 0xE2, 0x2E, 0x82, 0x66, 0xCA, 0x60, 0xC0,
-0x29, 0x23, 0xAB, 0x0D, 0x53, 0x4E, 0x6F, 0xD5, 0xDB, 0x37, 0x45, 0xDE, 0xFD,
-0x8E, 0x2F, 0x03, 0xFF, 0x6A, 0x72, 0x6D, 0x6C, 0x5B, 0x51, 0x8D, 0x1B, 0xAF,
-0x92, 0xBB, 0xDD, 0xBC, 0x7F, 0x11, 0xD9, 0x5C, 0x41, 0x1F, 0x10, 0x5A, 0xD8,
-0x0A, 0xC1, 0x31, 0x88, 0xA5, 0xCD, 0x7B, 0xBD, 0x2D, 0x74, 0xD0, 0x12, 0xB8,
-0xE5, 0xB4, 0xB0, 0x89, 0x69, 0x97, 0x4A, 0x0C, 0x96, 0x77, 0x7E, 0x65, 0xB9,
-0xF1, 0x09, 0xC5, 0x6E, 0xC6, 0x84, 0x18, 0xF0, 0x7D, 0xEC, 0x3A, 0xDC, 0x4D,
-0x20, 0x79, 0xEE, 0x5F, 0x3E, 0xD7, 0xCB, 0x39, 0x48
-|]
-
-let aes_sbox_fwd_table : list(bits(8)) = [|
-0x63, 0x7c, 0x77, 0x7b, 0xf2, 0x6b, 0x6f, 0xc5, 0x30, 0x01, 0x67, 0x2b, 0xfe,
-0xd7, 0xab, 0x76, 0xca, 0x82, 0xc9, 0x7d, 0xfa, 0x59, 0x47, 0xf0, 0xad, 0xd4,
-0xa2, 0xaf, 0x9c, 0xa4, 0x72, 0xc0, 0xb7, 0xfd, 0x93, 0x26, 0x36, 0x3f, 0xf7,
-0xcc, 0x34, 0xa5, 0xe5, 0xf1, 0x71, 0xd8, 0x31, 0x15, 0x04, 0xc7, 0x23, 0xc3,
-0x18, 0x96, 0x05, 0x9a, 0x07, 0x12, 0x80, 0xe2, 0xeb, 0x27, 0xb2, 0x75, 0x09,
-0x83, 0x2c, 0x1a, 0x1b, 0x6e, 0x5a, 0xa0, 0x52, 0x3b, 0xd6, 0xb3, 0x29, 0xe3,
-0x2f, 0x84, 0x53, 0xd1, 0x00, 0xed, 0x20, 0xfc, 0xb1, 0x5b, 0x6a, 0xcb, 0xbe,
-0x39, 0x4a, 0x4c, 0x58, 0xcf, 0xd0, 0xef, 0xaa, 0xfb, 0x43, 0x4d, 0x33, 0x85,
-0x45, 0xf9, 0x02, 0x7f, 0x50, 0x3c, 0x9f, 0xa8, 0x51, 0xa3, 0x40, 0x8f, 0x92,
-0x9d, 0x38, 0xf5, 0xbc, 0xb6, 0xda, 0x21, 0x10, 0xff, 0xf3, 0xd2, 0xcd, 0x0c,
-0x13, 0xec, 0x5f, 0x97, 0x44, 0x17, 0xc4, 0xa7, 0x7e, 0x3d, 0x64, 0x5d, 0x19,
-0x73, 0x60, 0x81, 0x4f, 0xdc, 0x22, 0x2a, 0x90, 0x88, 0x46, 0xee, 0xb8, 0x14,
-0xde, 0x5e, 0x0b, 0xdb, 0xe0, 0x32, 0x3a, 0x0a, 0x49, 0x06, 0x24, 0x5c, 0xc2,
-0xd3, 0xac, 0x62, 0x91, 0x95, 0xe4, 0x79, 0xe7, 0xc8, 0x37, 0x6d, 0x8d, 0xd5,
-0x4e, 0xa9, 0x6c, 0x56, 0xf4, 0xea, 0x65, 0x7a, 0xae, 0x08, 0xba, 0x78, 0x25,
-0x2e, 0x1c, 0xa6, 0xb4, 0xc6, 0xe8, 0xdd, 0x74, 0x1f, 0x4b, 0xbd, 0x8b, 0x8a,
-0x70, 0x3e, 0xb5, 0x66, 0x48, 0x03, 0xf6, 0x0e, 0x61, 0x35, 0x57, 0xb9, 0x86,
-0xc1, 0x1d, 0x9e, 0xe1, 0xf8, 0x98, 0x11, 0x69, 0xd9, 0x8e, 0x94, 0x9b, 0x1e,
-0x87, 0xe9, 0xce, 0x55, 0x28, 0xdf, 0x8c, 0xa1, 0x89, 0x0d, 0xbf, 0xe6, 0x42,
-0x68, 0x41, 0x99, 0x2d, 0x0f, 0xb0, 0x54, 0xbb, 0x16
-|]
-
-let aes_sbox_inv_table : list(bits(8)) = [|
-0x52, 0x09, 0x6a, 0xd5, 0x30, 0x36, 0xa5, 0x38, 0xbf, 0x40, 0xa3, 0x9e, 0x81,
-0xf3, 0xd7, 0xfb, 0x7c, 0xe3, 0x39, 0x82, 0x9b, 0x2f, 0xff, 0x87, 0x34, 0x8e,
-0x43, 0x44, 0xc4, 0xde, 0xe9, 0xcb, 0x54, 0x7b, 0x94, 0x32, 0xa6, 0xc2, 0x23,
-0x3d, 0xee, 0x4c, 0x95, 0x0b, 0x42, 0xfa, 0xc3, 0x4e, 0x08, 0x2e, 0xa1, 0x66,
-0x28, 0xd9, 0x24, 0xb2, 0x76, 0x5b, 0xa2, 0x49, 0x6d, 0x8b, 0xd1, 0x25, 0x72,
-0xf8, 0xf6, 0x64, 0x86, 0x68, 0x98, 0x16, 0xd4, 0xa4, 0x5c, 0xcc, 0x5d, 0x65,
-0xb6, 0x92, 0x6c, 0x70, 0x48, 0x50, 0xfd, 0xed, 0xb9, 0xda, 0x5e, 0x15, 0x46,
-0x57, 0xa7, 0x8d, 0x9d, 0x84, 0x90, 0xd8, 0xab, 0x00, 0x8c, 0xbc, 0xd3, 0x0a,
-0xf7, 0xe4, 0x58, 0x05, 0xb8, 0xb3, 0x45, 0x06, 0xd0, 0x2c, 0x1e, 0x8f, 0xca,
-0x3f, 0x0f, 0x02, 0xc1, 0xaf, 0xbd, 0x03, 0x01, 0x13, 0x8a, 0x6b, 0x3a, 0x91,
-0x11, 0x41, 0x4f, 0x67, 0xdc, 0xea, 0x97, 0xf2, 0xcf, 0xce, 0xf0, 0xb4, 0xe6,
-0x73, 0x96, 0xac, 0x74, 0x22, 0xe7, 0xad, 0x35, 0x85, 0xe2, 0xf9, 0x37, 0xe8,
-0x1c, 0x75, 0xdf, 0x6e, 0x47, 0xf1, 0x1a, 0x71, 0x1d, 0x29, 0xc5, 0x89, 0x6f,
-0xb7, 0x62, 0x0e, 0xaa, 0x18, 0xbe, 0x1b, 0xfc, 0x56, 0x3e, 0x4b, 0xc6, 0xd2,
-0x79, 0x20, 0x9a, 0xdb, 0xc0, 0xfe, 0x78, 0xcd, 0x5a, 0xf4, 0x1f, 0xdd, 0xa8,
-0x33, 0x88, 0x07, 0xc7, 0x31, 0xb1, 0x12, 0x10, 0x59, 0x27, 0x80, 0xec, 0x5f,
-0x60, 0x51, 0x7f, 0xa9, 0x19, 0xb5, 0x4a, 0x0d, 0x2d, 0xe5, 0x7a, 0x9f, 0x93,
-0xc9, 0x9c, 0xef, 0xa0, 0xe0, 0x3b, 0x4d, 0xae, 0x2a, 0xf5, 0xb0, 0xc8, 0xeb,
-0xbb, 0x3c, 0x83, 0x53, 0x99, 0x61, 0x17, 0x2b, 0x04, 0x7e, 0xba, 0x77, 0xd6,
-0x26, 0xe1, 0x69, 0x14, 0x63, 0x55, 0x21, 0x0c, 0x7d
-|]
-
-/* Lookup function - takes an index and a list, and retrieves the
- * x'th element of that list.
- */
-val sbox_lookup : (bits(8), list(bits(8))) -> bits(8)
-function sbox_lookup(x, table) = {
-  match (x, table) {
-    (0x00, t0::tn) => t0,
-    (   y, t0::tn) => sbox_lookup(x - 0x01, tn)
-  }
-}
-
-/* Easy function to perform a forward AES SBox operation on 1 byte. */
-val aes_sbox_fwd : bits(8) -> bits(8)
-function aes_sbox_fwd(x) = sbox_lookup(x, aes_sbox_fwd_table)
-
-/* Easy function to perform an inverse AES SBox operation on 1 byte. */
-val aes_sbox_inv : bits(8) -> bits(8)
-function aes_sbox_inv(x) = sbox_lookup(x, aes_sbox_inv_table)
-
-/* AES SubWord function used in the key expansion
- * - Applies the forward sbox to each byte in the input word.
- */
-val aes_subword_fwd : bits(32) -> bits(32)
-function aes_subword_fwd(x) = {
-  aes_sbox_fwd(x[31..24]) @
-  aes_sbox_fwd(x[23..16]) @
-  aes_sbox_fwd(x[15.. 8]) @
-  aes_sbox_fwd(x[ 7.. 0])
-}
-
-/* AES Inverse SubWord function.
- * - Applies the inverse sbox to each byte in the input word.
- */
-val aes_subword_inv : bits(32) -> bits(32)
-function aes_subword_inv(x) = {
-  aes_sbox_inv(x[31..24]) @
-  aes_sbox_inv(x[23..16]) @
-  aes_sbox_inv(x[15.. 8]) @
-  aes_sbox_inv(x[ 7.. 0])
-}
-
-/* Easy function to perform an SM4 SBox operation on 1 byte. */
-val sm4_sbox : bits(8) -> bits(8)
-function sm4_sbox(x) = sbox_lookup(x, sm4_sbox_table)
-
-val aes_get_column : (bits(128), nat) -> bits(32)
-function aes_get_column(state,c) = (state >> (to_bits(7, 32 * c)))[31..0]
-
-/* 64-bit to 64-bit function which applies the AES forward sbox to each byte
- * in a 64-bit word.
- */
-val aes_apply_fwd_sbox_to_each_byte : bits(64) -> bits(64)
-function aes_apply_fwd_sbox_to_each_byte(x) = {
-  aes_sbox_fwd(x[63..56]) @
-  aes_sbox_fwd(x[55..48]) @
-  aes_sbox_fwd(x[47..40]) @
-  aes_sbox_fwd(x[39..32]) @
-  aes_sbox_fwd(x[31..24]) @
-  aes_sbox_fwd(x[23..16]) @
-  aes_sbox_fwd(x[15.. 8]) @
-  aes_sbox_fwd(x[ 7.. 0])
-}
-
-/* 64-bit to 64-bit function which applies the AES inverse sbox to each byte
- * in a 64-bit word.
- */
-val aes_apply_inv_sbox_to_each_byte : bits(64) -> bits(64)
-function aes_apply_inv_sbox_to_each_byte(x) = {
-  aes_sbox_inv(x[63..56]) @
-  aes_sbox_inv(x[55..48]) @
-  aes_sbox_inv(x[47..40]) @
-  aes_sbox_inv(x[39..32]) @
-  aes_sbox_inv(x[31..24]) @
-  aes_sbox_inv(x[23..16]) @
-  aes_sbox_inv(x[15.. 8]) @
-  aes_sbox_inv(x[ 7.. 0])
-}
-
-/*
- * AES full-round transformation functions.
- */
-
-val getbyte : (bits(64), int) -> bits(8)
-function getbyte(x, i) = (x >> to_bits(6, i * 8))[7..0]
-
-val aes_rv64_shiftrows_fwd : (bits(64), bits(64)) -> bits(64)
-function aes_rv64_shiftrows_fwd(rs2, rs1) = {
-  getbyte(rs1, 3) @
-  getbyte(rs2, 6) @
-  getbyte(rs2, 1) @
-  getbyte(rs1, 4) @
-  getbyte(rs2, 7) @
-  getbyte(rs2, 2) @
-  getbyte(rs1, 5) @
-  getbyte(rs1, 0)
-}
-
-val aes_rv64_shiftrows_inv : (bits(64), bits(64)) -> bits(64)
-function aes_rv64_shiftrows_inv(rs2, rs1) = {
-  getbyte(rs2, 3) @
-  getbyte(rs2, 6) @
-  getbyte(rs1, 1) @
-  getbyte(rs1, 4) @
-  getbyte(rs1, 7) @
-  getbyte(rs2, 2) @
-  getbyte(rs2, 5) @
-  getbyte(rs1, 0)
-}
-
-/* 128-bit to 128-bit implementation of the forward AES ShiftRows transform.
- * Byte 0 of state is input column 0, bits  7..0.
- * Byte 5 of state is input column 1, bits 15..8.
- */
-val aes_shift_rows_fwd : bits(128) -> bits(128)
-function aes_shift_rows_fwd(x) = {
-  let ic3 : bits(32) = aes_get_column(x, 3);
-  let ic2 : bits(32) = aes_get_column(x, 2);
-  let ic1 : bits(32) = aes_get_column(x, 1);
-  let ic0 : bits(32) = aes_get_column(x, 0);
-  let oc0 : bits(32) = ic3[31..24] @ ic2[23..16] @ ic1[15.. 8] @ ic0[ 7.. 0];
-  let oc1 : bits(32) = ic0[31..24] @ ic3[23..16] @ ic2[15.. 8] @ ic1[ 7.. 0];
-  let oc2 : bits(32) = ic1[31..24] @ ic0[23..16] @ ic3[15.. 8] @ ic2[ 7.. 0];
-  let oc3 : bits(32) = ic2[31..24] @ ic1[23..16] @ ic0[15.. 8] @ ic3[ 7.. 0];
-  (oc3 @ oc2 @ oc1 @ oc0) /* Return value */
-}
-
-/* 128-bit to 128-bit implementation of the inverse AES ShiftRows transform.
- * Byte 0 of state is input column 0, bits  7..0.
- * Byte 5 of state is input column 1, bits 15..8.
- */
-val aes_shift_rows_inv : bits(128) -> bits(128)
-function aes_shift_rows_inv(x) = {
-  let ic3 : bits(32) = aes_get_column(x, 3); /* In column 3 */
-  let ic2 : bits(32) = aes_get_column(x, 2);
-  let ic1 : bits(32) = aes_get_column(x, 1);
-  let ic0 : bits(32) = aes_get_column(x, 0);
-  let oc0 : bits(32) = ic1[31..24] @ ic2[23..16] @ ic3[15.. 8] @ ic0[ 7.. 0];
-  let oc1 : bits(32) = ic2[31..24] @ ic3[23..16] @ ic0[15.. 8] @ ic1[ 7.. 0];
-  let oc2 : bits(32) = ic3[31..24] @ ic0[23..16] @ ic1[15.. 8] @ ic2[ 7.. 0];
-  let oc3 : bits(32) = ic0[31..24] @ ic1[23..16] @ ic2[15.. 8] @ ic3[ 7.. 0];
-  (oc3 @ oc2 @ oc1 @ oc0) /* Return value */
-}
-
-/* Applies the forward sub-bytes step of AES to a 128-bit vector
- * representation of its state.
- */
-val aes_subbytes_fwd : bits(128) -> bits(128)
-function aes_subbytes_fwd(x) = {
-  let oc0 : bits(32) = aes_subword_fwd(aes_get_column(x, 0));
-  let oc1 : bits(32) = aes_subword_fwd(aes_get_column(x, 1));
-  let oc2 : bits(32) = aes_subword_fwd(aes_get_column(x, 2));
-  let oc3 : bits(32) = aes_subword_fwd(aes_get_column(x, 3));
-  (oc3 @ oc2 @ oc1 @ oc0) /* Return value */
-}
-
-/* Applies the inverse sub-bytes step of AES to a 128-bit vector
- * representation of its state.
- */
-val aes_subbytes_inv : bits(128) -> bits(128)
-function aes_subbytes_inv(x) = {
-  let oc0 : bits(32) = aes_subword_inv(aes_get_column(x, 0));
-  let oc1 : bits(32) = aes_subword_inv(aes_get_column(x, 1));
-  let oc2 : bits(32) = aes_subword_inv(aes_get_column(x, 2));
-  let oc3 : bits(32) = aes_subword_inv(aes_get_column(x, 3));
-  (oc3 @ oc2 @ oc1 @ oc0) /* Return value */
-}
-
-/* Applies the forward MixColumns step of AES to a 128-bit vector
- * representation of its state.
- */
-val aes_mixcolumns_fwd : bits(128) -> bits(128)
-function aes_mixcolumns_fwd(x) = {
-  let oc0 : bits(32) = aes_mixcolumn_fwd(aes_get_column(x, 0));
-  let oc1 : bits(32) = aes_mixcolumn_fwd(aes_get_column(x, 1));
-  let oc2 : bits(32) = aes_mixcolumn_fwd(aes_get_column(x, 2));
-  let oc3 : bits(32) = aes_mixcolumn_fwd(aes_get_column(x, 3));
-  (oc3 @ oc2 @ oc1 @ oc0) /* Return value */
-}
-
-/* Applies the inverse MixColumns step of AES to a 128-bit vector
- * representation of its state.
- */
-val aes_mixcolumns_inv : bits(128) -> bits(128)
-function aes_mixcolumns_inv(x) = {
-  let oc0 : bits(32) = aes_mixcolumn_inv(aes_get_column(x, 0));
-  let oc1 : bits(32) = aes_mixcolumn_inv(aes_get_column(x, 1));
-  let oc2 : bits(32) = aes_mixcolumn_inv(aes_get_column(x, 2));
-  let oc3 : bits(32) = aes_mixcolumn_inv(aes_get_column(x, 3));
-  (oc3 @ oc2 @ oc1 @ oc0) /* Return value */
-}
-
 /* Performs the word rotation for AES key schedule
 */
 

--- a/src/vector-crypto.adoc
+++ b/src/vector-crypto.adoc
@@ -4123,56 +4123,17 @@ include::sailcomment:aes_mixcolumns_inv[]
 
 sail::aes_mixcolumns_inv[part=source]
 
-[source,sail]
-----
-/* Performs the word rotation for AES key schedule
-*/
+sail::brev8[type=val,part=source]
 
-val aes_rotword : bits(32) -> bits(32)
-function aes_rotword(x) = {
-  let a0 : bits (8) = x[ 7.. 0];
-  let a1 : bits (8) = x[15.. 8];
-  let a2 : bits (8) = x[23..16];
-  let a3 : bits (8) = x[31..24];
-  (a0 @ a3 @ a2 @ a1) /* Return Value */
-}
+sail::brev8[part=source]
 
-val brev : bits(SEW) -> bits(SEW)
-function brev(x) = {
-  let output : bits(SEW) = 0;
-  foreach (i from 0 to SEW-8 by 8)
-    output[i+7..i] = reverse_bits_in_byte(input[i+7..i]);
-  output /* Return Value */
-}
+sail::reverse_bits[type=val,part=source]
 
-val reverse_bits_in_byte : bits(8) -> bits(8)
-function reverse_bits_in_byte(x) = {
-  let output : bits(8) = 0;
-  foreach (i from 0 to 7)
-    output[i] = x[7-i]);
-  output /* Return Value */
-}
+sail::reverse_bits[part=source]
 
-val rev8 : bits(SEW) -> bits(SEW)
-function rev8(x) = {     // endian swap
-  let output : bits(SEW) = 0;
-    let j = SEW - 1;
-    foreach (k from 0 to (SEW - 8) by 8) {
-      output[k..(k + 7)] = x[(j - 7)..j];
-      j = j - 8;
-  output /* Return Value */
-  }
-  RETIRE_SUCCESS
+sail::rev8[type=val,part=source]
 
+sail::rev8[part=source]
 
-val rol32 : bits(32) -> bits(32)
-function ROL32(x,n) = (X << N) | (X >> (32 - N))
+sail::zvk_sm4_subword[part=source]
 
-val sm4_subword : bits(32) -> bits(32)
-function sm4_subword(x) = {
-  sm4_sbox(x[31..24]) @
-  sm4_sbox(x[23..16]) @
-  sm4_sbox(x[15.. 8]) @
-  sm4_sbox(x[ 7.. 0])
-}
-----


### PR DESCRIPTION
This needs a doc bundle generated by the main branch of the Sail compiler.
The one generated by Sail 0.19.1 will not have the needed doc comments. 

The doc bundle also needs a Sail model containing [this](https://github.com/riscv/sail-riscv/pull/1321) commit.
