### PR TITLE
Add Sail for the instructions in the CMO extensions.

### DIFF
--- a/src/cmo.adoc
+++ b/src/cmo.adoc
@@ -835,6 +835,15 @@ the sequence of performing a clean operation just before deallocating all cached
 copies in the set of coherent caches._
 ====
 
+Operation::
+[source,sail]
+--
+include::sail:execute[clause="ZICBOM(CBO_CLEAN, _)",part=source]
+
+include::sail:cbo_clean_flush_enabled[]
+
+--
+
 [#insns-cbo_flush,reftext="Cache Block Flush"]
 ==== cbo.flush
 
@@ -867,6 +876,12 @@ agent executing the instruction.
 
 The assembly _offset_ operand may be omitted. If it isn't then any expression
 that computes the offset shall evaluate to zero.
+
+Operation::
+[source,sail]
+--
+include::sail:execute[clause="ZICBOM(CBO_FLUSH, _)",part=source]
+--
 
 [#insns-cbo_inval,reftext="Cache Block Invalidate"]
 ==== cbo.inval
@@ -912,6 +927,12 @@ the sequence of performing a write transfer to memory just before performing an
 invalidate operation._
 ====
 
+Operation::
+[source,sail]
+--
+include::sail:execute[clause="ZICBOM(CBO_INVAL, _)",part=source]
+--
+
 [#insns-cbo_zero,reftext="Cache Block Zero"]
 ==== cbo.zero
 
@@ -944,6 +965,12 @@ may not update the entire set of bytes atomically.
 
 The assembly _offset_ operand may be omitted. If it isn't then any expression
 that computes the offset shall evaluate to zero.
+
+Operation::
+[source,sail]
+--
+include::sail:execute[clause="ZICBOZ(_)",part=source]
+--
 
 [#insns-prefetch_i,reftext="Cache Block Prefetch for Instruction Fetch"]
 ==== prefetch.i
@@ -982,6 +1009,15 @@ accessed by an instruction fetch in order to improve memory access latency, but
 this behavior is not required._
 ====
 
+Operation::
+[source,sail]
+--
+include::sail:execute[clause="ZICBOP(_)",part=source]
+--
+
+The Sail model does not model prefetches.
+
+
 [#insns-prefetch_r,reftext="Cache Block Prefetch for Data Read"]
 ==== prefetch.r
 
@@ -1019,6 +1055,14 @@ accessed by a data read in order to improve memory access latency, but this
 behavior is not required._
 ====
 
+Operation::
+[source,sail]
+--
+include::sail:execute[clause="ZICBOP(_)",part=source]
+--
+
+The Sail model does not model prefetches.
+
 [#insns-prefetch_w,reftext="Cache Block Prefetch for Data Write"]
 ==== prefetch.w
 
@@ -1055,3 +1099,11 @@ _An implementation may opt to cache a copy of the cache block in a cache
 accessed by a data write in order to improve memory access latency, but this
 behavior is not required._
 ====
+
+Operation::
+[source,sail]
+--
+include::sail:execute[clause="ZICBOP(_)",part=source]
+--
+
+The Sail model does not model prefetches.


### PR DESCRIPTION
This restores the sections that were meant for Sail instruction semantics that were removed in https://github.com/riscv/riscv-isa-manual/pull/2198