### PR TITLE
Add instruction encoding diagrams from Sail

### DIFF
--- a/src/b-st-ext.adoc
+++ b/src/b-st-ext.adoc
@@ -1018,6 +1018,9 @@ Encoding::
 ]}
 ....
 
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="ZBA_RTYPEUW(_,_,_,_)",type=mapping,right]
+
 Description::
 This instruction performs an XLEN-wide addition between _rs2_ and the zero-extended least-significant word of _rs1_.
 
@@ -1065,6 +1068,9 @@ Encoding::
 ]}
 ....
 
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="ZBB_RTYPE(_,_,_,ANDN)",type=mapping,right]
+
 Description::
 This instruction performs the bitwise logical AND operation between _rs1_ and the bitwise inversion of _rs2_.
 
@@ -1110,6 +1116,9 @@ Encoding::
     { bits:  7, name: 0x24, attr: ['BCLR/BEXT'] },
 ]}
 ....
+
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="ZBS_RTYPE(_,_,_,BCLR)",type=mapping,right]
 
 Description::
 This instruction returns _rs1_ with a single bit cleared at the index specified in _rs2_.
@@ -1167,6 +1176,9 @@ Encoding (RV64)::
 ]}
 ....
 
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="ZBS_IOP(_,_,_,BCLRI)",type=mapping,right]
+
 Description::
 This instruction returns _rs1_ with a single bit cleared at the index specified in _shamt_.
 The index is read from the lower log2(XLEN) bits of _shamt_.
@@ -1211,6 +1223,9 @@ Encoding::
     { bits:  7, name: 0x24, attr: ['BCLR/BEXT'] },
 ]}
 ....
+
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="ZBS_RTYPE(_,_,_,BEXT)",type=mapping,right]
 
 Description::
 This instruction returns a single bit extracted from _rs1_ at the index specified in _rs2_.
@@ -1268,6 +1283,9 @@ Encoding (RV64)::
 ]}
 ....
 
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="ZBS_IOP(_,_,_,BEXTI)",type=mapping,right]
+
 Description::
 This instruction returns a single bit extracted from _rs1_ at the index specified in _shamt_.
 The index is read from the lower log2(XLEN) bits of _shamt_.
@@ -1311,6 +1329,9 @@ Encoding::
     { bits:  7, name: 0x34, attr: ['BINV'] },
 ]}
 ....
+
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="ZBS_RTYPE(_,_,_,BINV)",type=mapping,right]
 
 Description::
 This instruction returns _rs1_ with a single bit inverted at the index specified in _rs2_.
@@ -1368,6 +1389,9 @@ Encoding (RV64)::
 ]}
 ....
 
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="ZBS_IOP(_,_,_,BINVI)",type=mapping,right]
+
 Description::
 This instruction returns _rs1_ with a single bit inverted at the index specified in _shamt_.
 The index is read from the lower log2(XLEN) bits of _shamt_.
@@ -1411,6 +1435,9 @@ Encoding::
     { bits:  7, name: 0x14, attr: ['BSET'] },
 ]}
 ....
+
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="ZBS_RTYPE(_,_,_,BSET)",type=mapping,right]
 
 Description::
 This instruction returns _rs1_ with a single bit set at the index specified in _rs2_.
@@ -1468,6 +1495,9 @@ Encoding (RV64)::
 ]}
 ....
 
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="ZBS_IOP(_,_,_,BSETI)",type=mapping,right]
+
 Description::
 This instruction returns _rs1_ with a single bit set at the index specified in _shamt_.
 The index is read from the lower log2(XLEN) bits of _shamt_.
@@ -1511,6 +1541,9 @@ Encoding::
     { bits:  7, name: 0x5, attr: ['MINMAX/CLMUL'] },
 ]}
 ....
+
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="CLMUL(_,_,_)",type=mapping,right]
 
 Description::
 clmul produces the lower half of the 2·XLEN carry-less product.
@@ -1558,6 +1591,9 @@ Encoding::
 ]}
 ....
 
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="CLMULH(_,_,_)",type=mapping,right]
+
 Description::
 clmulh produces the upper half of the 2·XLEN carry-less product.
 
@@ -1604,6 +1640,9 @@ Encoding::
     { bits:  7, name: 0x5, attr: ['MINMAX/CLMUL'] },
 ]}
 ....
+
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="CLMULR(_,_,_)",type=mapping,right]
 
 Description::
 *clmulr* produces bits 2·XLEN−2:XLEN-1 of the 2·XLEN carry-less
@@ -1657,6 +1696,9 @@ Encoding::
 ]}
 ....
 
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="CLZ(_,_)",type=mapping,right]
+
 Description::
 This instruction counts the number of 0's before the first 1, starting at the most-significant bit (i.e., XLEN-1) and progressing to bit 0. Accordingly, if the input is 0, the output is XLEN, and if the most-significant bit of the input is a 1, the output is 0.
 
@@ -1698,6 +1740,9 @@ Encoding::
     { bits:  7, name: 0x30, attr: ['CLZW'] },
 ]}
 ....
+
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="CLZW(_,_)",type=mapping,right]
 
 Description::
 This instruction counts the number of 0's before the first 1 starting at bit 31 and progressing to bit 0.
@@ -1741,6 +1786,10 @@ Encoding::
     { bits:  7, name: 0x30, attr: ['CPOP'] },
 ]}
 ....
+
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="CPOP(_,_)",type=mapping,right]
+
 Description::
 This instructions counts the number of 1's (i.e., set bits) in the source register.
 
@@ -1791,6 +1840,10 @@ Encoding::
     { bits:  7, name: 0x30, attr: ['CPOPW'] },
 ]}
 ....
+
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="CPOPW(_,_)",type=mapping,right]
+
 Description::
 This instructions counts the number of 1's (i.e., set bits) in the least-significant word of the source register.
 
@@ -1832,6 +1885,9 @@ Encoding::
     { bits:  7, name: 0x30, attr: ['CTZ/CTZW'] },
 ]}
 ....
+
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="CTZ(_,_)",type=mapping,right]
 
 Description::
 This instruction counts the number of 0's before the first 1, starting at the least-significant bit (i.e., 0) and progressing to the most-significant bit (i.e., XLEN-1).
@@ -1876,6 +1932,9 @@ Encoding::
 ]}
 ....
 
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="CTZW(_,_)",type=mapping,right]
+
 Description::
 This instruction counts the number of 0's before the first 1, starting at the least-significant bit (i.e., 0) and progressing to the most-significant bit of the least-significant word (i.e., 31). Accordingly, if the least-significant word is 0, the output is 32, and if the least-significant bit of the input is a 1, the output is 0.
 
@@ -1917,6 +1976,9 @@ Encoding::
     { bits:  7, name: 0x05, attr: ['MINMAX/CLMUL'] },
 ]}
 ....
+
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="ZBB_RTYPE(_,_,_,MAX)",type=mapping,right]
 
 Description::
 This instruction returns the larger of two signed integers.
@@ -1970,6 +2032,9 @@ Encoding::
 ]}
 ....
 
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="ZBB_RTYPE(_,_,_,MAXU)",type=mapping,right]
+
 Description::
 This instruction returns the larger of two unsigned integers.
 
@@ -2011,6 +2076,9 @@ Encoding::
     { bits:  7, name: 0x05, attr: ['MINMAX/CLMUL'] },
 ]}
 ....
+
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="ZBB_RTYPE(_,_,_,MIN)",type=mapping,right]
 
 Description::
 This instruction returns the smaller of two signed integers.
@@ -2054,6 +2122,9 @@ Encoding::
 ]}
 ....
 
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="ZBB_RTYPE(_,_,_,MINU)",type=mapping,right]
+
 Description::
 This instruction returns the smaller of two unsigned integers.
 
@@ -2094,6 +2165,9 @@ Encoding::
     { bits: 12, name: 0x287 }
 ]}
 ....
+
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="ORCB(_,_)",type=mapping,right]
 
 Description::
 Combines the bits within each byte using bitwise logical OR.
@@ -2137,6 +2211,9 @@ Encoding::
     { bits:  7, name: 0x20, attr: ['ORN'] },
 ]}
 ....
+
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="ZBB_RTYPE(_,_,_,ORN)",type=mapping,right]
 
 Description::
 This instruction performs the bitwise logical OR operation between _rs1_ and the bitwise inversion of _rs2_.
@@ -2183,6 +2260,9 @@ Encoding::
     {bits: 7, name: 0x4, attr:['PACK']},
 ]}
 ....
+
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="ZBKB_RTYPE(_,_,_,PACK)",type=mapping,right]
 
 Description::
 The pack instruction packs the XLEN/2-bit lower halves of _rs1_ and _rs2_ into
@@ -2234,6 +2314,9 @@ Encoding::
 ]}
 ....
 
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="ZBKB_RTYPE(_,_,_,PACKH)",type=mapping,right]
+
 Description::
 The packh instruction packs the least-significant bytes of
 _rs1_ and _rs2_ into the 16 least-significant bits of _rd_,
@@ -2277,6 +2360,9 @@ Encoding::
 {bits: 7, name: 0x4},
 ]}
 ....
+
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="ZBKB_PACKW(_,_,_)",type=mapping,right]
 
 Description::
 This instruction packs the low 16 bits of
@@ -2341,6 +2427,9 @@ Encoding (RV64)::
 ]}
 ....
 
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="REV8(_,_)",type=mapping,right]
+
 Description::
 This instruction reverses the order of the bytes in _rs_.
 
@@ -2401,6 +2490,9 @@ Encoding::
 ]}
 ....
 
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="BREV8(_,_)",type=mapping,right]
+
 Description::
 This instruction reverses the order of the bits in every byte of a register.
 
@@ -2442,6 +2534,9 @@ Encoding::
     { bits:  7, name: 0x30, attr: ['ROL'] },
 ]}
 ....
+
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="ZBB_RTYPE(_,_,_,ROL)",type=mapping,right]
 
 Description::
 This instruction performs a rotate left of _rs1_ by the amount in least-significant log2(XLEN) bits of _rs2_.
@@ -2489,6 +2584,9 @@ Encoding::
 ]}
 ....
 
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="ZBB_RTYPEW(_,_,_,ROLW)",type=mapping,right]
+
 Description::
 This instruction performs a rotate left on the least-significant word of  _rs1_ by the amount in least-significant 5 bits of _rs2_.
 The resulting word value is sign-extended by copying bit 31 to all of the more-significant bits.
@@ -2535,6 +2633,9 @@ Encoding::
     { bits:  7, name: 0x30, attr: ['ROR'] },
 ]}
 ....
+
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="ZBB_RTYPE(_,_,_,ROR)",type=mapping,right]
 
 Description::
 This instruction performs a rotate right of _rs1_ by the amount in least-significant log2(XLEN) bits of _rs2_.
@@ -2595,6 +2696,9 @@ Encoding (RV64)::
 ]}
 ....
 
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="RORI(_,_,_)",type=mapping,right]
+
 Description::
 This instruction performs a rotate right of _rs1_ by the amount in the least-significant log2(XLEN) bits of _shamt_.
 For RV32, the encodings corresponding to shamt[5]=1 are reserved.
@@ -2641,6 +2745,9 @@ Encoding::
     { bits:  7, name: 0x30, attr: ['RORIW'] },
 ]}
 ....
+
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="RORIW(_,_,_)",type=mapping,right]
 
 Description::
 This instruction performs a rotate right on the least-significant word
@@ -2693,6 +2800,9 @@ Encoding::
 ]}
 ....
 
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="ZBB_RTYPEW(_,_,_,RORW)",type=mapping,right]
+
 Description::
 This instruction performs a rotate right on the least-significant word of  _rs1_ by the amount in least-significant 5 bits of _rs2_.
 The resultant word is sign-extended by copying bit 31 to all of the more-significant bits.
@@ -2740,6 +2850,9 @@ Encoding::
 ]}
 ....
 
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="ZBB_EXTOP(_,_,SEXTB)",type=mapping,right]
+
 Description::
 This instruction sign-extends the least-significant byte in the source to XLEN by copying the most-significant bit in the byte (i.e., bit 7) to all of the more-significant bits.
 
@@ -2781,6 +2894,9 @@ Encoding::
     { bits:  7, name: 0x30 },
 ]}
 ....
+
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="ZBB_EXTOP(_,_,SEXTH)",type=mapping,right]
 
 Description::
 This instruction sign-extends the least-significant halfword in _rs_ to XLEN by copying the most-significant bit in the halfword (i.e., bit 15) to all of the more-significant bits.
@@ -3103,6 +3219,9 @@ Encoding::
 ]}
 ....
 
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="SLLIUW(_,_,_)",type=mapping,right]
+
 Description::
 This instruction takes the least-significant word of _rs1_, zero-extends it, and shifts it left by the immediate.
 
@@ -3151,6 +3270,9 @@ Encoding::
 {bits: 7, name: 0x4},
 ]}
 ....
+
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="UNZIP(_,_)",type=mapping,right]
 
 Description::
 This instruction scatters all of the odd and even bits of a source word into
@@ -3206,6 +3328,9 @@ Encoding::
 ]}
 ....
 
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="ZBB_RTYPE(_,_,_,XNOR)",type=mapping,right]
+
 Description::
 This instruction performs the bit-wise exclusive-NOR operation on _rs1_ and _rs2_.
 
@@ -3252,6 +3377,9 @@ Encoding::
 ]}
 ....
 
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="XPERM8(_,_,_)",type=mapping,right]
+
 Description::
 The xperm8 instruction operates on bytes.
 The _rs1_ register contains a vector of XLEN/8 8-bit elements.
@@ -3297,6 +3425,9 @@ Encoding::
 {bits: 7, name: 0x14},
 ]}
 ....
+
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="XPERM4(_,_,_)",type=mapping,right]
 
 Description::
 The xperm4 instruction operates on nibbles.
@@ -3357,6 +3488,9 @@ Encoding (RV64)::
 ]}
 ....
 
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="ZBB_EXTOP(_,_,ZEXTH)",type=mapping,right]
+
 Description::
 This instruction zero-extends the least-significant halfword of the source to XLEN by inserting 0's into all of the bits more significant than 15.
 
@@ -3405,6 +3539,9 @@ Encoding::
 {bits: 7, name: 0x4},
 ]}
 ....
+
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="ZIP(_,_)",type=mapping,right]
 
 Description::
 This instruction gathers bits from the high and low halves of the source

--- a/src/bfloat16.adoc
+++ b/src/bfloat16.adoc
@@ -471,6 +471,8 @@ Encoding::
 ]}
 ....
 
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="FCVT_BF16_S(_,_,_)",type=mapping,right]
 
 [NOTE]
 ====
@@ -518,6 +520,9 @@ Encoding::
 {bits: 5, name: '01000', attr: 'fcvt'},
 ]}
 ....
+
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="FCVT_S_BF16(_,_,_)",type=mapping,right]
 
 [NOTE]
 ====
@@ -576,6 +581,9 @@ Encoding::
 ]}
 ....
 
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="VFNCVTBF16_F_F_W(_,_,_)",type=mapping,right]
+
 Reserved Encodings::
 * `SEW` is any value other than 16
 
@@ -632,6 +640,9 @@ Encoding::
 {bits: 6, name: '010010', attr:['VFUNARY0']},
 ]}
 ....
+
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="VFWCVTBF16_F_F_V(_,_,_)",type=mapping,right]
 
 Reserved Encodings::
 * `SEW` is any value other than 16
@@ -695,6 +706,9 @@ Encoding (Vector-Vector)::
 ]}
 ....
 
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="VFWMACCBF16_VV(_,_,_,_)",type=mapping,right]
+
 Encoding (Vector-Scalar)::
 [wavedrom, , svg]
 ....
@@ -708,6 +722,9 @@ Encoding (Vector-Scalar)::
 {bits: 6, name: '111011', attr:['vfwmaccbf16']},
 ]}
 ....
+
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="VFWMACCBF16_VF(_,_,_,_)",type=mapping,right]
 
 Reserved Encodings::
 * `SEW` is any value other than 16

--- a/src/c-st-ext.adoc
+++ b/src/c-st-ext.adoc
@@ -601,6 +601,10 @@ always 16-byte aligned.
 include::images/wavedrom/c-ciw.edn[]
 //.CIW format.
 (((compressed, CIW)))
+
+Encoding (Sail)::
+include::sailwavedrom:encdec_compressed[left-clause="C_ADDI4SPN(_,_)",type=mapping,right]
+
 C.ADDI4SPN (add immediate to stack pointer, non-destructive)
 is a CIW-format instruction that adds a _zero_-extended
 non-zero immediate, scaled by 4, to the stack pointer, `x2`, and writes
@@ -614,6 +618,9 @@ reserved.
 include::images/wavedrom/c-ci.edn[]
 //.CI format.
 (((compressed, CI)))
+
+Encoding (Sail)::
+include::sailwavedrom:encdec_compressed[left-clause="C_SLLI(_,_)",type=mapping,right]
 
 C.SLLI is a CI-format instruction that performs a logical left shift of
 the value in register _rd_ then writes the result to _rd_. The shift
@@ -656,6 +663,9 @@ where all other immediates are sign-extended.
 include::images/wavedrom/c-andi.edn[]
 //.C.ANDI format
 (((compressed, C.ANDI)))
+
+Encoding (Sail)::
+include::sailwavedrom:encdec_compressed[left-clause="C_ANDI(_,_)",type=mapping,right]
 
 C.ANDI is a CB-format instruction that computes the bitwise AND of the
 value in register _rd′_ and the sign-extended 6-bit
@@ -771,6 +781,9 @@ with _imm_≠0 encode HINTs.
 [[c-breakpoint-instr]]
 include::images/wavedrom/c-breakpoint-instr.edn[]
 ((((compressed. C.BREAKPOINTINSTR))))
+
+Encoding (Sail)::
+include::sailwavedrom:encdec_compressed[left-clause="C_EBREAK()",type=mapping,right]
 
 Debuggers can use the `C.EBREAK` instruction, which expands to `ebreak`,
 to cause control to be transferred back to the debugging environment.

--- a/src/cmo.adoc
+++ b/src/cmo.adoc
@@ -819,6 +819,14 @@ Encoding::
 ]}
 ....
 
+include::sailwavedrom:encdec[left-clause="ZICBOM(_,_)",type=mapping,right]
+
+where `CBO-OP = CBO_CLEAN` and
+[source,sail]
+----
+include::sail:encdec_cbop[type=mapping,left-clause="CBO_CLEAN"]
+----
+
 Description::
 
 A *cbo.clean* instruction performs a clean operation on the cache block whose
@@ -856,6 +864,14 @@ Encoding::
 ]}
 ....
 
+include::sailwavedrom:encdec[left-clause="ZICBOM(_,_)",type=mapping,right]
+
+where `CBO-OP = CBO_FLUSH` and
+[source,sail]
+----
+include::sail:encdec_cbop[type=mapping,left-clause="CBO_FLUSH"]
+----
+
 Description::
 
 A *cbo.flush* instruction performs a flush operation on the cache block whose
@@ -888,6 +904,14 @@ Encoding::
  { bits: 12, name: 0x000, attr: ['CBO.INVAL'] },
 ]}
 ....
+
+include::sailwavedrom:encdec[left-clause="ZICBOM(_,_)",type=mapping,right]
+
+where `CBO-OP = CBO_INVAL` and
+[source,sail]
+----
+include::sail:encdec_cbop[type=mapping,left-clause="CBO_INVAL"]
+----
 
 Description::
 
@@ -933,6 +957,8 @@ Encoding::
 ]}
 ....
 
+include::sailwavedrom:encdec[left-clause="ZICBOZ(_)",type=mapping,right]
+
 Description::
 
 A *cbo.zero* instruction performs stores of zeros to the full set of bytes
@@ -967,6 +993,14 @@ Encoding::
  { bits: 7, name: 'imm[11:5]',  attr: ['offset[11:5]'] },
 ]}
 ....
+
+include::sailwavedrom:encdec[left-clause="ZICBOP(_,_,_)",type=mapping,right]
+
+where `PREFETCH-OP = PREFETCH_I` and
+[source,sail]
+----
+include::sail:encdec_cbop_zicbop[type=mapping,left-clause="PREFETCH_I"]
+----
 
 Description::
 
@@ -1005,6 +1039,14 @@ Encoding::
 ]}
 ....
 
+include::sailwavedrom:encdec[left-clause="ZICBOP(_,_,_)",type=mapping,right]
+
+where `PREFETCH-OP = PREFETCH_R` and
+[source,sail]
+----
+include::sail:encdec_cbop_zicbop[type=mapping,left-clause="PREFETCH_R"]
+----
+
 Description::
 
 A *prefetch.r* instruction indicates to hardware that the cache block whose
@@ -1041,6 +1083,14 @@ Encoding::
  { bits: 7, name: 'imm[11:5]',  attr: ['offset[11:5]'] },
 ]}
 ....
+
+include::sailwavedrom:encdec[left-clause="ZICBOP(_,_,_)",type=mapping,right]
+
+where `PREFETCH-OP = PREFETCH_W` and
+[source,sail]
+----
+include::sail:encdec_cbop_zicbop[type=mapping,left-clause="PREFETCH_W"]
+----
 
 Description::
 

--- a/src/d-st-ext.adoc
+++ b/src/d-st-ext.adoc
@@ -107,6 +107,10 @@ include::images/wavedrom/double-ls.edn[]
 [[double-ls]]
 //.Double-precision load and store
 
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="LOAD_FP(_,_,_,_)",type=mapping,right]
+include::sailwavedrom:encdec[left-clause="STORE_FP(_,_,_,_)",type=mapping,right]
+
 FLD and FSD are only guaranteed to execute atomically if the effective
 address is naturally aligned and XLEN&#8805;64.
 

--- a/src/f-st-ext.adoc
+++ b/src/f-st-ext.adoc
@@ -235,6 +235,10 @@ include::images/wavedrom/sp-load-store-2.edn[]
 [[sp-ldst]]
 //.SP load and store
 
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="LOAD_FP(_,_,_,_)",type=mapping,right]
+include::sailwavedrom:encdec[left-clause="STORE_FP(_,_,_,_)",type=mapping,right]
+
 FLW and FSW are only guaranteed to execute atomically if the effective
 address is naturally aligned.
 

--- a/src/rv32.adoc
+++ b/src/rv32.adoc
@@ -455,6 +455,9 @@ include::images/wavedrom/ct-unconditional.edn[]
 [[ct-unconditional]]
 //.The unconditional-jump instruction, JAL
 
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="JAL(_,_)",type=mapping,right]
+
 The indirect jump instruction JALR (jump and link register) uses the I-type encoding.
 [#norm:jalr_target]#The target address is obtained by adding the
 sign-extended 12-bit I-immediate to the register _rs1_, then setting the
@@ -473,6 +476,9 @@ _imm_=0.
 include::images/wavedrom/ct-unconditional-2.edn[]
 [[ct-unconditional-2]]
 //.The indirect unconditional-jump instruction, JALR
+
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="JALR(_,_)",type=mapping,right]
 
 [NOTE]
 ====
@@ -707,6 +713,10 @@ memory byte addresses to the less-significant register bytes.
 include::images/wavedrom/load-store.edn[]
 [[load-store,load and store]]
 //.Load and store instructions
+
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="LOAD(_,_,_,_,_)",type=mapping,right]
+include::sailwavedrom:encdec[left-clause="STORE(_,_,_,_)",type=mapping,right]
 
 Load and store instructions transfer a value between the registers and
 memory. Loads are encoded in the I-type format and stores are S-type.

--- a/src/rv64.adoc
+++ b/src/rv64.adoc
@@ -43,6 +43,9 @@ include::images/wavedrom/rv64i-base-int.edn[]
 [[rv64i-base-int]]
 //.RV64I register-immediate instructions
 
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="ADDIW(_,_,_)",type=mapping,right]
+
 [#norm:addiw_op]#ADDIW is an RV64I instruction that adds the sign-extended 12-bit
 immediate to register _rs1_ and produces the proper sign extension of a
 32-bit result in _rd_.# [#norm:addiw_overflow]#Overflows are ignored and the result is the low

--- a/src/scalar-crypto.adoc
+++ b/src/scalar-crypto.adoc
@@ -436,6 +436,9 @@ Encoding::
 ]}
 ....
 
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="AES32DSI(_,_,_,_)",type=mapping,right]
+
 Description::
 This instruction sources a single byte from `rs2` according to `bs`.
 To this it applies the inverse AES SBox operation, and XOR's the result with
@@ -489,6 +492,9 @@ Encoding::
 {bits: 2, name: 'bs'},
 ]}
 ....
+
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="AES32DSMI(_,_,_,_)",type=mapping,right]
 
 Description::
 This instruction sources a single byte from `rs2` according to `bs`.
@@ -544,6 +550,9 @@ Encoding::
 ]}
 ....
 
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="AES32ESI(_,_,_,_)",type=mapping,right]
+
 Description::
 This instruction sources a single byte from `rs2` according to `bs`.
 To this it applies the forward AES SBox operation,
@@ -598,6 +607,9 @@ Encoding::
 ]}
 ....
 
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="AES32ESMI(_,_,_,_)",type=mapping,right]
+
 Description::
 This instruction sources a single byte from `rs2` according to `bs`.
 To this it applies the forward AES SBox operation, and a partial forward
@@ -651,6 +663,9 @@ Encoding::
 {bits: 2, name: 0x0},
 ]}
 ....
+
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="AES64DS(_,_,_)",type=mapping,right]
 
 Description::
 Uses the two 64-bit source registers to represent the entire AES state,
@@ -719,6 +734,9 @@ Encoding::
 ]}
 ....
 
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="AES64DSM(_,_,_)",type=mapping,right]
+
 Description::
 Uses the two 64-bit source registers to represent the entire AES state,
 and produces _half_ of the next round output, applying the Inverse ShiftRows,
@@ -786,6 +804,9 @@ Encoding::
 ]}
 ....
 
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="AES64ES(_,_,_)",type=mapping,right]
+
 Description::
 Uses the two 64-bit source registers to represent the entire AES state,
 and produces _half_ of the next round output, applying the ShiftRows and
@@ -852,6 +873,9 @@ Encoding::
 {bits: 2, name: 0x0},
 ]}
 ....
+
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="AES64ESM(_,_,_)",type=mapping,right]
 
 Description::
 Uses the two 64-bit source registers to represent the entire AES state,
@@ -921,6 +945,9 @@ Encoding::
 ]}
 ....
 
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="AES64IM(_,_)",type=mapping,right]
+
 Description::
 The instruction applies the inverse MixColumns
 transformation to two columns of the state array, packed into a single
@@ -980,6 +1007,9 @@ Encoding::
 ]}
 ....
 
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="AES64KS1I(_,_,_)",type=mapping,right]
+
 Description::
 This instruction implements the rotation, SubBytes and Round Constant
 addition steps of the AES block cipher Key Schedule.
@@ -1038,6 +1068,9 @@ Encoding::
 {bits: 2, name: 0x1},
 ]}
 ....
+
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="AES64KS2(_,_,_)",type=mapping,right]
 
 Description::
 This instruction implements the additional XOR'ing of key words as
@@ -1139,6 +1172,9 @@ Encoding::
     { bits: 12, name: 0x687 }
 ]}
 ....
+
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="BREV8(_,_)",type=mapping,right]
 
 Description::
 This instruction reverses the order of the bits in every byte of a register.
@@ -1324,6 +1360,9 @@ Encoding::
 ]}
 ....
 
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="ZBKB_RTYPE(_,_,_,PACK)",type=mapping,right]
+
 Description::
 The pack instruction packs the XLEN/2-bit lower halves of _rs1_ and _rs2_ into
 _rd_, with _rs1_ in the lower half and _rs2_ in the upper half.
@@ -1367,6 +1406,9 @@ Encoding::
     {bits: 7, name: 0x4, attr: ['PACKH']},
 ]}
 ....
+
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="ZBKB_RTYPE(_,_,_,PACKH)",type=mapping,right]
 
 Description::
 And the packh instruction packs the least-significant bytes of
@@ -1413,6 +1455,9 @@ Encoding::
 {bits: 7, name: 0x4},
 ]}
 ....
+
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="ZBKB_PACKW(_,_,_)",type=mapping,right]
 
 Description::
 This instruction packs the low 16 bits of
@@ -1838,6 +1883,9 @@ Encoding::
 ]}
 ....
 
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="SHA256SIG0(_,_)",type=mapping,right]
+
 Description::
 This instruction is supported for both RV32 and RV64 base architectures.
 For RV32, the entire `XLEN` source register is operated on.
@@ -1896,6 +1944,9 @@ Encoding::
 {bits: 2, name: 0x0},
 ]}
 ....
+
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="SHA256SIG1(_,_)",type=mapping,right]
 
 Description::
 This instruction is supported for both RV32 and RV64 base architectures.
@@ -1956,6 +2007,9 @@ Encoding::
 ]}
 ....
 
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="SHA256SUM0(_,_)",type=mapping,right]
+
 Description::
 This instruction is supported for both RV32 and RV64 base architectures.
 For RV32, the entire `XLEN` source register is operated on.
@@ -2015,6 +2069,9 @@ Encoding::
 ]}
 ....
 
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="SHA256SUM1(_,_)",type=mapping,right]
+
 Description::
 This instruction is supported for both RV32 and RV64 base architectures.
 For RV32, the entire `XLEN` source register is operated on.
@@ -2073,6 +2130,9 @@ Encoding::
 {bits: 2, name: 0x1},
 ]}
 ....
+
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="SHA512SIG0H(_,_,_)",type=mapping,right]
 
 Description::
 This instruction is implemented on RV32 only.
@@ -2142,6 +2202,9 @@ Encoding::
 ]}
 ....
 
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="SHA512SIG0L(_,_,_)",type=mapping,right]
+
 Description::
 This instruction is implemented on RV32 only.
 Used to compute the Sigma0 transform of the SHA2-512 hash function
@@ -2209,6 +2272,9 @@ Encoding::
 {bits: 2, name: 0x1},
 ]}
 ....
+
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="SHA512SIG1H(_,_,_)",type=mapping,right]
 
 Description::
 This instruction is implemented on RV32 only.
@@ -2278,6 +2344,9 @@ Encoding::
 ]}
 ....
 
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="SHA512SIG1L(_,_,_)",type=mapping,right]
+
 Description::
 This instruction is implemented on RV32 only.
 Used to compute the Sigma1 transform of the SHA2-512 hash function
@@ -2345,6 +2414,9 @@ Encoding::
 {bits: 2, name: 0x1},
 ]}
 ....
+
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="SHA512SUM0R(_,_,_)",type=mapping,right]
 
 Description::
 This instruction is implemented on RV32 only.
@@ -2414,6 +2486,9 @@ Encoding::
 ]}
 ....
 
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="SHA512SUM1R(_,_,_)",type=mapping,right]
+
 Description::
 This instruction is implemented on RV32 only.
 Used to compute the Sum1 transform of the SHA2-512 hash function.
@@ -2482,6 +2557,9 @@ Encoding::
 ]}
 ....
 
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="SHA512SIG0(_,_)",type=mapping,right]
+
 Description::
 This instruction is supported for the RV64 base architecture.
 It implements the Sigma0 transform of the SHA2-512 hash function.
@@ -2536,6 +2614,9 @@ Encoding::
 {bits: 2, name: 0x0},
 ]}
 ....
+
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="SHA512SIG1(_,_)",type=mapping,right]
 
 Description::
 This instruction is supported for the RV64 base architecture.
@@ -2592,6 +2673,9 @@ Encoding::
 ]}
 ....
 
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="SHA512SUM0(_,_)",type=mapping,right]
+
 Description::
 This instruction is supported for the RV64 base architecture.
 It implements the Sum0 transform of the SHA2-512 hash function.
@@ -2647,6 +2731,9 @@ Encoding::
 ]}
 ....
 
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="SHA512SUM1(_,_)",type=mapping,right]
+
 Description::
 This instruction is supported for the RV64 base architecture.
 It implements the Sum1 transform of the SHA2-512 hash function.
@@ -2701,6 +2788,9 @@ Encoding::
 {bits: 2, name: 0x0},
 ]}
 ....
+
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="SM3P0(_,_)",type=mapping,right]
 
 Description::
 This instruction is supported for the RV32 and RV64 base architectures.
@@ -2758,6 +2848,9 @@ Encoding::
 {bits: 2, name: 0x0},
 ]}
 ....
+
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="SM3P1(_,_)",type=mapping,right]
 
 Description::
 This instruction is supported for the RV32 and RV64 base architectures.
@@ -2817,6 +2910,9 @@ Encoding::
 ]}
 ....
 
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="SM4ED(_,_,_,_)",type=mapping,right]
+
 Description::
 Implements a T-tables in hardware style approach to accelerating the
 SM4 round function.
@@ -2873,6 +2969,9 @@ Encoding::
 ]}
 ....
 
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="SM4KS(_,_,_,_)",type=mapping,right]
+
 Description::
 Implements a T-tables in hardware style approach to accelerating the
 SM4 Key Schedule.
@@ -2928,6 +3027,9 @@ Encoding::
 {bits: 7, name: 0x4},
 ]}
 ....
+
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="UNZIP(_,_)",type=mapping,right]
 
 Description::
 This instruction scatters all of the odd and even bits of a source word into
@@ -3031,6 +3133,9 @@ Encoding::
 ]}
 ....
 
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="XPERM8(_,_,_)",type=mapping,right]
+
 Description::
 The xperm8 instruction operates on bytes.
 The _rs1_ register contains a vector of XLEN/8 8-bit elements.
@@ -3078,6 +3183,9 @@ Encoding::
 {bits: 7, name: 0x14},
 ]}
 ....
+
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="XPERM4(_,_,_)",type=mapping,right]
 
 Description::
 The xperm4 instruction operates on nibbles.
@@ -3127,6 +3235,9 @@ Encoding::
 {bits: 7, name: 0x4},
 ]}
 ....
+
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="ZIP(_,_)",type=mapping,right]
 
 Description::
 This instruction gathers bits from the high and low halves of the source

--- a/src/vector-crypto.adoc
+++ b/src/vector-crypto.adoc
@@ -1210,6 +1210,15 @@ Encoding (Vector-Vector)::
 ]}
 ....
 
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="VAESDF(_,_,_)",type=mapping,right]
+
+where `VAESDF.OP = ZVK_VAESDF_VV` and
+[source,sail]
+----
+include::sail:encdec_vaesdf[type=mapping,left-clause="ZVK_VAESDF_VV"]
+----
+
 Encoding (Vector-Scalar)::
 [wavedrom, , svg]
 ....
@@ -1223,6 +1232,16 @@ Encoding (Vector-Scalar)::
 {bits: 6, name: '101001`'},
 ]}
 ....
+
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="VAESDF(_,_,_)",type=mapping,right]
+
+where `VAESDF.OP = ZVK_VAESDF_VS` and
+[source,sail]
+----
+include::sail:encdec_vaesdf[type=mapping,left-clause="ZVK_VAESDF_VS"]
+----
+
 Reserved Encodings::
 * `SEW` is any value other than 32
 * Only for the `.vs` form: the `vd` register group overlaps the `vs2` scalar element group
@@ -1289,6 +1308,15 @@ Encoding (Vector-Vector)::
 ]}
 ....
 
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="VAESDM(_,_,_)",type=mapping,right]
+
+where `VAESDM.OP = ZVK_VAESDM_VV` and
+[source,sail]
+----
+include::sail:encdec_vaesdm[type=mapping,left-clause="ZVK_VAESDM_VV"]
+----
+
 Encoding (Vector-Scalar)::
 [wavedrom, , svg]
 ....
@@ -1302,6 +1330,16 @@ Encoding (Vector-Scalar)::
 {bits: 6, name: '101001'},
 ]}
 ....
+
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="VAESDM(_,_,_)",type=mapping,right]
+
+where `VAESDM.OP = ZVK_VAESDM_VS` and
+[source,sail]
+----
+include::sail:encdec_vaesdm[type=mapping,left-clause="ZVK_VAESDM_VS"]
+----
+
 Reserved Encodings::
 * `SEW` is any value other than 32
 * Only for the `.vs` form: the `vd` register group overlaps the `vs2` scalar element group
@@ -1372,6 +1410,15 @@ Encoding (Vector-Vector)::
 ]}
 ....
 
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="VAESEF(_,_,_)",type=mapping,right]
+
+where `VAESEF.OP = ZVK_VAESEF_VV` and
+[source,sail]
+----
+include::sail:encdec_vaesef[type=mapping,left-clause="ZVK_VAESEF_VV"]
+----
+
 Encoding (Vector-Scalar)::
 [wavedrom, , svg]
 ....
@@ -1385,6 +1432,16 @@ Encoding (Vector-Scalar)::
 {bits: 6, name: '101001'},
 ]}
 ....
+
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="VAESEF(_,_,_)",type=mapping,right]
+
+where `VAESEF.OP = ZVK_VAESEF_VS` and
+[source,sail]
+----
+include::sail:encdec_vaesef[type=mapping,left-clause="ZVK_VAESEF_VS"]
+----
+
 Reserved Encodings::
 * `SEW` is any value other than 32
 * Only for the `.vs` form: the `vd` register group overlaps the `vs2` scalar element group
@@ -1455,6 +1512,15 @@ Encoding (Vector-Vector)::
 ]}
 ....
 
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="VAESEM(_,_,_)",type=mapping,right]
+
+where `VAESEM.OP = ZVK_VAESEM_VV` and
+[source,sail]
+----
+include::sail:encdec_vaesem[type=mapping,left-clause="ZVK_VAESEM_VV"]
+----
+
 Encoding (Vector-Scalar)::
 [wavedrom, , svg]
 ....
@@ -1468,6 +1534,16 @@ Encoding (Vector-Scalar)::
 {bits: 6, name: '101001'},
 ]}
 ....
+
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="VAESEM(_,_,_)",type=mapping,right]
+
+where `VAESEM.OP = ZVK_VAESEM_VS` and
+[source,sail]
+----
+include::sail:encdec_vaesem[type=mapping,left-clause="ZVK_VAESEM_VS"]
+----
+
 Reserved Encodings::
 * `SEW` is any value other than 32
 * Only for the `.vs` form: the `vd` register group overlaps the `vs2` scalar element group
@@ -1536,6 +1612,10 @@ Encoding::
 {bits: 6, name: '100010'},
 ]}
 ....
+
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="VAESKF1_VI(_,_,_)",type=mapping,right]
+
 Reserved Encodings::
 * `SEW` is any value other than 32
 
@@ -1624,6 +1704,10 @@ Encoding::
 {bits: 6, name: '101010'},
 ]}
 ....
+
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="VAESKF2_VI(_,_,_)",type=mapping,right]
+
 Reserved Encodings::
 * `SEW` is any value other than 32
 
@@ -1708,6 +1792,10 @@ Encoding (Vector-Scalar)::
 {bits: 6, name: '101001'},
 ]}
 ....
+
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="VAESZ_VS(_,_)",type=mapping,right]
+
 Reserved Encodings::
 * `SEW` is any value other than 32
 * The `vd` register group overlaps the `vs2` register
@@ -1789,6 +1877,9 @@ Encoding (Vector-Vector)::
 ]}
 ....
 
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="VANDN_VV(_,_,_,_)",type=mapping,right]
+
 Encoding (Vector-Scalar)::
 [wavedrom, , svg]
 ....
@@ -1802,6 +1893,9 @@ Encoding (Vector-Scalar)::
 {bits: 6, name: '000001'},
 ]}
 ....
+
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="VANDN_VX(_,_,_,_)",type=mapping,right]
 
 Vector-Vector Arguments::
 
@@ -1892,6 +1986,9 @@ Encoding (Vector)::
 ]}
 ....
 
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="VBREV_V(_,_,_)",type=mapping,right]
+
 Arguments::
 
 [%autowidth]
@@ -1939,6 +2036,9 @@ Encoding (Vector)::
 {bits: 6, name: '010010'},
 ]}
 ....
+
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="VBREV8_V(_,_,_)",type=mapping,right]
 
 Arguments::
 
@@ -1999,6 +2099,9 @@ Encoding (Vector-Vector)::
 ]}
 ....
 
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="VCLMUL_VV(_,_,_,_)",type=mapping,right]
+
 Encoding (Vector-Scalar)::
 [wavedrom, , svg]
 ....
@@ -2012,6 +2115,10 @@ Encoding (Vector-Scalar)::
 {bits: 6, name: '001100'},
 ]}
 ....
+
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="VCLMUL_VX(_,_,_,_)",type=mapping,right]
+
 Reserved Encodings::
 * `SEW` is any value other than 64
 
@@ -2086,6 +2193,9 @@ Encoding (Vector-Vector)::
 ]}
 ....
 
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="VCLMULH_VV(_,_,_,_)",type=mapping,right]
+
 Encoding (Vector-Scalar)::
 [wavedrom, , svg]
 ....
@@ -2099,6 +2209,10 @@ Encoding (Vector-Scalar)::
 {bits: 6, name: '001101'},
 ]}
 ....
+
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="VCLMULH_VX(_,_,_,_)",type=mapping,right]
+
 Reserved Encodings::
 * `SEW` is any value other than 64
 
@@ -2164,6 +2278,9 @@ Encoding (Vector)::
 ]}
 ....
 
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="VCLZ_V(_,_,_)",type=mapping,right]
+
 Arguments::
 
 [%autowidth]
@@ -2212,6 +2329,9 @@ Encoding (Vector)::
 ]}
 ....
 
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="VCPOP_V(_,_,_)",type=mapping,right]
+
 Arguments::
 
 [%autowidth]
@@ -2257,6 +2377,9 @@ Encoding (Vector)::
 {bits: 6, name: '010010'},
 ]}
 ....
+
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="VCTZ_V(_,_,_)",type=mapping,right]
 
 Arguments::
 
@@ -2307,6 +2430,10 @@ Encoding::
 {bits: 6, name: '101100'},
 ]}
 ....
+
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="VGHSH_VV(_,_,_)",type=mapping,right]
+
 Reserved Encodings::
 * `SEW` is any value other than 32
 
@@ -2399,6 +2526,10 @@ Encoding::
 {bits: 6, name: '101000'},
 ]}
 ....
+
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="VGMUL_VV(_,_)",type=mapping,right]
+
 Reserved Encodings::
 * `SEW` is any value other than 32
 
@@ -2495,6 +2626,9 @@ Encoding (Vector)::
 ]}
 ....
 
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="VREV8_V(_,_,_)",type=mapping,right]
+
 Arguments::
 
 [%autowidth]
@@ -2553,6 +2687,9 @@ Encoding (Vector-Vector)::
 ]}
 ....
 
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="VROL_VV(_,_,_,_)",type=mapping,right]
+
 Encoding (Vector-Scalar)::
 [wavedrom, , svg]
 ....
@@ -2566,6 +2703,9 @@ Encoding (Vector-Scalar)::
 {bits: 6, name: '010101'},
 ]}
 ....
+
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="VROL_VX(_,_,_,_)",type=mapping,right]
 
 Vector-Vector Arguments::
 
@@ -2651,6 +2791,9 @@ Encoding (Vector-Vector)::
 ]}
 ....
 
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="VROR_VV(_,_,_,_)",type=mapping,right]
+
 Encoding (Vector-Scalar)::
 [wavedrom, , svg]
 ....
@@ -2664,6 +2807,9 @@ Encoding (Vector-Scalar)::
 {bits: 6, name: '010100'},
 ]}
 ....
+
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="VROR_VX(_,_,_,_)",type=mapping,right]
 
 Encoding (Vector-Immediate)::
 [wavedrom, , svg]
@@ -2679,6 +2825,9 @@ Encoding (Vector-Immediate)::
 {bits: 5, name: '01010'},
 ]}
 ....
+
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="VROR_VI(_,_,_,_)",type=mapping,right]
 
 Vector-Vector Arguments::
 
@@ -2759,6 +2908,15 @@ Encoding (Vector-Vector) High part::
 ]}
 ....
 
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="ZVKSHA2TYPE(_,_,_,_)",type=mapping,right]
+
+where `VSHA2C.OP = ZVK_VSHA2CH_VV` and
+[source,sail]
+----
+include::sail:encdec_vsha2[type=mapping,left-clause="ZVK_VSHA2CH_VV"]
+----
+
 Encoding (Vector-Vector) Low part::
 [wavedrom, , svg]
 ....
@@ -2772,6 +2930,16 @@ Encoding (Vector-Vector) Low part::
 {bits: 6, name: '101111'},
 ]}
 ....
+
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="ZVKSHA2TYPE(_,_,_,_)",type=mapping,right]
+
+where `VSHA2C.OP = ZVK_VSHA2CL_VV` and
+[source,sail]
+----
+include::sail:encdec_vsha2[type=mapping,left-clause="ZVK_VSHA2CL_VV"]
+----
+
 Reserved Encodings::
 * `zvknha`: `SEW` is any value other than 32
 * `zvknhb`: `SEW` is any value other than 32 or 64
@@ -2915,6 +3083,10 @@ Encoding (Vector-Vector)::
 {bits: 6, name: '101101'},
 ]}
 ....
+
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="VSHA2MS_VV(_,_,_)",type=mapping,right]
+
 Reserved Encodings::
 * `zvknha`: `SEW` is any value other than 32
 * `zvknhb`: `SEW` is any value other than 32 or 64
@@ -3061,6 +3233,10 @@ Encoding::
 {bits: 6, name: '101011'},
 ]}
 ....
+
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="VSM3C_VI(_,_,_)",type=mapping,right]
+
 Reserved Encodings::
 * `SEW` is any value other than 32
 * The `vd` register group overlaps with the `vs2` register group
@@ -3180,6 +3356,10 @@ Encoding::
 {bits: 6, name: '100000'},
 ]}
 ....
+
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="VSM3ME_VV(_,_,_)",type=mapping,right]
+
 Reserved Encodings::
 * `SEW` is any value other than 32
 * The `vd` register group overlaps with the `vs2` register group.
@@ -3272,6 +3452,10 @@ Encoding::
 {bits: 6, name: '100001'},
 ]}
 ....
+
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="VSM4K_VI(_,_,_)",type=mapping,right]
+
 Reserved Encodings::
 * `SEW` is any value other than 32
 
@@ -3436,6 +3620,9 @@ Encoding (Vector-Vector)::
 ]}
 ....
 
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="ZVKSM4RTYPE(ZVK_VSM4R_VV,_,_)",type=mapping,right]
+
 Encoding (Vector-Scalar)::
 [wavedrom, , svg]
 ....
@@ -3449,6 +3636,10 @@ Encoding (Vector-Scalar)::
 {bits: 6, name: '101001'},
 ]}
 ....
+
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="ZVKSM4RTYPE(ZVK_VSM4R_VS,_,_)",type=mapping,right]
+
 Reserved Encodings::
 * `SEW` is any value other than 32
 * Only for the `.vs` form: the `vd` register group overlaps the `vs2` register
@@ -3538,6 +3729,9 @@ Encoding (Vector-Vector)::
 ]}
 ....
 
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="VWSLL_VV(_,_,_,_)",type=mapping,right]
+
 Encoding (Vector-Scalar)::
 [wavedrom, , svg]
 ....
@@ -3552,6 +3746,9 @@ Encoding (Vector-Scalar)::
 ]}
 ....
 
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="VWSLL_VX(_,_,_,_)",type=mapping,right]
+
 Encoding (Vector-Immediate)::
 [wavedrom, , svg]
 ....
@@ -3565,6 +3762,9 @@ Encoding (Vector-Immediate)::
 {bits: 6, name: '110101'},
 ]}
 ....
+
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="VWSLL_VI(_,_,_,_)",type=mapping,right]
 
 Vector-Vector Arguments::
 

--- a/src/zc.adoc
+++ b/src/zc.adoc
@@ -354,6 +354,9 @@ Encoding (RV32, RV64):
 ],config:{bits:16}}
 ....
 
+Encoding (Sail)::
+include::sailwavedrom:encdec_compressed[left-clause="C_LBU(_,_,_)",type=mapping,right]
+
 The immediate offset is formed as follows:
 
 [source,sail]
@@ -408,6 +411,9 @@ Encoding (RV32, RV64):
     { bits:  3, name: 0x4, attr: ['FUNCT3'] },
 ],config:{bits:16}}
 ....
+
+Encoding (Sail)::
+include::sailwavedrom:encdec_compressed[left-clause="C_LHU(_,_,_)",type=mapping,right]
 
 The immediate offset is formed as follows:
 
@@ -465,6 +471,9 @@ Encoding (RV32, RV64):
 ],config:{bits:16}}
 ....
 
+Encoding (Sail)::
+include::sailwavedrom:encdec_compressed[left-clause="C_LH(_,_,_)",type=mapping,right]
+
 The immediate offset is formed as follows:
 
 [source,sail]
@@ -519,6 +528,9 @@ Encoding (RV32, RV64):
     { bits:  3, name: 0x4, attr: ['FUNCT3'] },
 ],config:{bits:16}}
 ....
+
+Encoding (Sail)::
+include::sailwavedrom:encdec_compressed[left-clause="C_SB(_,_,_)",type=mapping,right]
 
 The immediate offset is formed as follows:
 
@@ -577,6 +589,9 @@ Encoding (RV32, RV64):
 ],config:{bits:16}}
 ....
 
+Encoding (Sail)::
+include::sailwavedrom:encdec_compressed[left-clause="C_SH(_,_,_)",type=mapping,right]
+
 The immediate offset is formed as follows:
 
 [source,sail]
@@ -632,6 +647,9 @@ Encoding (RV32, RV64):
     { bits:  3, name: 0x4, attr: ['FUNCT3'] },
 ],config:{bits:16}}
 ....
+
+Encoding (Sail)::
+include::sailwavedrom:encdec_compressed[left-clause="C_ZEXT_B(_)",type=mapping,right]
 
 Description::
 
@@ -690,6 +708,9 @@ Encoding (RV32, RV64):
 ],config:{bits:16}}
 ....
 
+Encoding (Sail)::
+include::sailwavedrom:encdec_compressed[left-clause="C_SEXT_B(_)",type=mapping,right]
+
 Description::
 
 This instruction takes a single source/destination operand.
@@ -742,6 +763,9 @@ Encoding (RV32, RV64):
     { bits:  3, name: 0x4, attr: ['FUNCT3'] },
 ],config:{bits:16}}
 ....
+
+Encoding (Sail)::
+include::sailwavedrom:encdec_compressed[left-clause="C_ZEXT_H(_)",type=mapping,right]
 
 Description::
 
@@ -797,6 +821,9 @@ Encoding (RV32, RV64):
 ],config:{bits:16}}
 ....
 
+Encoding (Sail)::
+include::sailwavedrom:encdec_compressed[left-clause="C_SEXT_H(_)",type=mapping,right]
+
 Description::
 
 This instruction takes a single source/destination operand.
@@ -850,6 +877,9 @@ Encoding (RV64):
     { bits:  3, name: 0x4, attr: ['FUNCT3'] },
 ],config:{bits:16}}
 ....
+
+Encoding (Sail)::
+include::sailwavedrom:encdec_compressed[left-clause="C_ZEXT_W(_)",type=mapping,right]
 
 Description::
 
@@ -908,6 +938,9 @@ Encoding (RV32, RV64):
 ],config:{bits:16}}
 ....
 
+Encoding (Sail)::
+include::sailwavedrom:encdec_compressed[left-clause="C_NOT(_)",type=mapping,right]
+
 Description::
 
 This instruction takes the one's complement of _rd'/rs1'_ and writes the result to the same register.
@@ -962,6 +995,9 @@ Encoding (RV32, RV64):
     { bits:  3, name: 0x4, attr: ['FUNCT3'] },
 ],config:{bits:16}}
 ....
+
+Encoding (Sail)::
+include::sailwavedrom:encdec_compressed[left-clause="C_MUL(_)",type=mapping,right]
 
 Description::
 

--- a/src/zifencei.adoc
+++ b/src/zifencei.adoc
@@ -66,6 +66,9 @@ include::images/wavedrom/zifencei-ff.edn[]
 //.FENCE.I instruction
 (((FENCE.I, synchronization)))
 
+Encoding (Sail)::
+include::sailwavedrom:encdec[left-clause="FENCEI()",type=mapping,right]
+
 The FENCE.I instruction is used to synchronize the instruction and data
 streams. RISC-V does not guarantee that stores to instruction memory
 will be made visible to instruction fetches on a RISC-V hart until that


### PR DESCRIPTION
This needs a model with riscv/sail-riscv#1337.

The original diagrams have been left in place for easier comparison.
    
The main difference between the two occurs when the manual has separate diagrams for RV32 and RV64, and Sail has a single clause with arch differences handled in `when` clause.
    
There are occasional infelicities when a Sail variable does not fit into the bitwidth of the diagram.

There are other spurious differences due to minor internal inconsistencies in the manual.
